### PR TITLE
Restore Python 3.8 compatibility for dictionary merge

### DIFF
--- a/python/solid_dmft/dmft_tools/matheval.py
+++ b/python/solid_dmft/dmft_tools/matheval.py
@@ -39,7 +39,10 @@ class MathExpr(object):
         "max": max,
         "pow": pow,
         "round": round,
-    } | {key: value for (key, value) in vars(math).items() if not key.startswith("_")}
+    }
+    functions.update(
+        {key: value for (key, value) in vars(math).items() if not key.startswith("_")}
+    )
 
     def __init__(self, expr):
         if any(elem in expr for elem in "\n#"):
@@ -53,4 +56,4 @@ class MathExpr(object):
         self.code = compile(node, "<string>", "eval")
 
     def __call__(self, **kwargs):
-        return eval(self.code, {"__builtins__": None}, self.functions | kwargs)
+        return eval(self.code, {"__builtins__": None}, {**self.functions, **kwargs})

--- a/python/solid_dmft/dmft_tools/solver.py
+++ b/python/solid_dmft/dmft_tools/solver.py
@@ -397,7 +397,7 @@ class SolverStructure:
 
             # Solve the impurity problem for icrsh shell
             # *************************************
-            self.triqs_solver.solve(h_int=self.h_int, **(self.solver_params | random_seed ))
+            self.triqs_solver.solve(h_int=self.h_int, **{ **self.solver_params, **random_seed })
             # *************************************
 
             # call postprocessing
@@ -413,7 +413,7 @@ class SolverStructure:
 
             # Solve the impurity problem for icrsh shell
             # *************************************
-            self.triqs_solver.solve(h_int=self.h_int, **(self.solver_params | random_seed ))
+            self.triqs_solver.solve(h_int=self.h_int, **{ **self.solver_params, **random_seed })
             # *************************************
 
             # call postprocessing
@@ -587,7 +587,7 @@ class SolverStructure:
 
             # Solve the impurity problem for icrsh shell
             # *************************************
-            self.triqs_solver.solve(h_int=self.h_int, **(self.solver_params | random_seed ))
+            self.triqs_solver.solve(h_int=self.h_int, **{ **self.solver_params, **random_seed })
             # *************************************
 
             # call postprocessing
@@ -604,7 +604,7 @@ class SolverStructure:
 
             # Solve the impurity problem for icrsh shell
             # *************************************
-            self.triqs_solver.solve(h_int=self.h_int, **(self.solver_params | random_seed ))
+            self.triqs_solver.solve(h_int=self.h_int, **{ **self.solver_params, **random_seed })
             # *************************************
 
             # call postprocessing


### PR DESCRIPTION
The `|` operator requires Python 3.9, which would then exclude Ubuntu 20.04 and other distros with older Python.