### PR TITLE
ci: build and cache base image separately

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -41,7 +41,20 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository }}_${{ matrix.name }}
 
-      - name: Build and push Docker image
+      - name: Build and cache base Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./Docker
+          file: ./Docker/${{ matrix.name }}_dockerfile
+          build-args: |
+            NCORES=2
+          target: base
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ github.ref_name }}-${{ matrix.name }}
+          cache-to: type=gha,mode=max,scope=${{ github.ref_name }}-${{ matrix.name }}
+
+      - name: Build and push final Docker image
         uses: docker/build-push-action@v5
         with:
           context: ./Docker
@@ -53,5 +66,3 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=${{ github.ref_name }}-${{ matrix.name }}
-          cache-to: type=gha,mode=max,scope=${{ github.ref_name }}-${{ matrix.name }}


### PR DESCRIPTION
This adds some duplication to the workflow file, but is a bit more efficient for the GitHub Action cache, because it prevents caching of layers which will never be reused.