### PR TITLE
Only use basename as target to copy seed and config

### DIFF
--- a/python/solid_dmft/main.py
+++ b/python/solid_dmft/main.py
@@ -108,8 +108,8 @@ def main(argv=sys.argv):
             # Copies h5 archive and config file to subfolder if are not there
             for file in (general_params['seedname']+'.h5',
                          general_params['config_file']):
-                if not os.path.isfile(general_params['jobname']+'/'+file):
-                    shutil.copyfile(file, general_params['jobname']+'/'+file)
+                if not os.path.isfile(general_params['jobname']+'/'+os.path.basename(file)):
+                    shutil.copyfile(file, general_params['jobname']+'/'+os.path.basename(file))
         mpi.barrier()
 
         # Runs dmft_cycle


### PR DESCRIPTION
Using `solid_dmft path/to/dmft.ini` results in
```python
shutil.copyfile("path/to/dmft.ini", "jobname/path/to/dmft.ini")
```
but `jobname` normally does not have the subdirectories `path/to/`, so better strip them off.

Maybe this needs to be done in other locations as well.