### PR TITLE
Broyden refactoring

### DIFF
--- a/python/solid_dmft/dmft_cycle.py
+++ b/python/solid_dmft/dmft_cycle.py
@@ -56,6 +56,7 @@ from solid_dmft.dmft_tools import afm_mapping
 from solid_dmft.dmft_tools import manipulate_chemical_potential as manipulate_mu
 from solid_dmft.dmft_tools import initial_self_energies as initial_sigma
 from solid_dmft.dmft_tools import greens_functions_mixer as gf_mixer
+from collections import deque
 
 
 def _determine_block_structure(sum_k, general_params, advanced_params):
@@ -342,10 +343,27 @@ def dmft_cycle(general_params, solver_params, advanced_params, dft_params,
         E_kin_dft = None
 
     # check for previous broyden data oterhwise initialize it:
-    if mpi.is_master_node() and  general_params['g0_mix_type'] == 'broyden':
+    #if mpi.is_master_node() and  general_params['g0_mix_type'] == 'broyden':
+    #    if not 'broyler' in archive['DMFT_results']:
+    #        archive['DMFT_results']['broyler'] = [{'mu' : [],'V': [], 'dV': [], 'F': [], 'dF': []}
+    #                                              for _ in range(sum_k.n_inequiv_shells)]
+    if mpi.is_master_node() and general_params['mix_type']=='broyden':
         if not 'broyler' in archive['DMFT_results']:
-            archive['DMFT_results']['broyler'] = [{'mu' : [],'V': [], 'dV': [], 'F': [], 'dF': []}
-                                                  for _ in range(sum_k.n_inequiv_shells)]
+            #archive['DMFT_results']['broyler'] = [{'mu' : [],'V': [], 'dV': [], 'F': [], 'dF': []}
+            #                                      for _ in range(sum_k.n_inequiv_shells)]
+
+            broyler_list = [{'mu' : [],'V': [], 'dV': [], 'F': [], 'dF': [],
+                'broy_max_it': general_params['broy_max_it'],
+                'deg_shell':sum_k.deg_shells[_icrsh1] }
+                for _icrsh1 in range(sum_k.n_inequiv_shells)]
+            archive['DMFT_results']['broyler'] = broyler_list
+
+            mpi.report("Testing mixing data initialization")
+            broyler_obj = gf_mixer.BroylerClass(broyler_list)
+            mpi.report(broyler_obj.__dict__)
+            mpi.report("Comparing with broyler list")
+            mpi.report(broyler_list)
+
 
     # Generates a rotation matrix to change the basis
     if general_params['set_rot'] != 'none':
@@ -631,8 +649,12 @@ def _dmft_step(sum_k, solvers, it, general_params,
 
         # mixing of G0 if wanted from the second iteration on
         if it > 1:
-            solvers[icrsh] = gf_mixer.mix_g0(solvers[icrsh], general_params, icrsh, archive,
-                                             G0_freq_previous[icrsh], it, sum_k.deg_shells[icrsh])
+            if 'G0'in general_params['mix_quantity']:
+               mpi.report(f"XXXXXXX Calling {general_params['mix_type']} mixing on {general_params['mix_quantity']}")
+               solvers[icrsh] = gf_mixer.mix_general(general_params, icrsh, solvers[icrsh], G0_freq_previous[icrsh], it = it, F_type='G0',
+                        deg_shell=sum_k.deg_shells[icrsh], archive=archive)
+            # solvers[icrsh] = gf_mixer.mix_g0(solvers[icrsh], general_params, icrsh, archive,
+            #                                  G0_freq_previous[icrsh], it, sum_k.deg_shells[icrsh])
 
         if general_params['solver_type'] in ['cthyb', 'ctint', 'hubbardI', 'inchworm']:
             solvers[icrsh].G0_freq << make_hermitian(solvers[icrsh].G0_freq)
@@ -690,7 +712,16 @@ def _dmft_step(sum_k, solvers, it, general_params,
     # if CPA average Sigma over impurities before mixing
     if general_params['dc'] and general_params['dc_type'] == 4:
         solvers = gf_mixer.mix_cpa(cpa_G0_freq, sum_k.n_inequiv_shells, solvers)
-    solvers = gf_mixer.mix_sigma(general_params, sum_k.n_inequiv_shells, solvers, Sigma_freq_previous)
+    #solvers = gf_mixer.mix_sigma(general_params, sum_k.n_inequiv_shells, solvers, Sigma_freq_previous)
+    
+    if 'Sigma'in general_params['mix_quantity']:
+        if it > 1:
+            mpi.report(f"XXXXXXX Calling {general_params['mix_type']} mixing on {general_params['mix_quantity']}")
+            for icrsh in range(sum_k.n_inequiv_shells):
+                solvers[icrsh] = gf_mixer.mix_general(general_params, icrsh, solvers[icrsh], Sigma_freq_previous[icrsh], F_type='Sigma', it=it,
+                            deg_shell=sum_k.deg_shells[icrsh], archive=archive)
+
+
 
     # calculate new DC
     # for the hartree solver the DC potential will be formally set to zero as it is already present in the Sigma

--- a/python/solid_dmft/dmft_tools/greens_functions_mixer.py
+++ b/python/solid_dmft/dmft_tools/greens_functions_mixer.py
@@ -33,7 +33,7 @@ from triqs.gf.descriptors import Fourier
 from triqs.gf.tools import inverse
 
 from . import legendre_filter
-
+from collections import deque
 
 def _bgf_to_vec(bgf, deg_shells=None):
     """
@@ -44,9 +44,9 @@ def _bgf_to_vec(bgf, deg_shells=None):
         deg_vecs = []
         for deg_block in deg_shells:
             deg_vecs.append(bgf[deg_block[0]])
-        vec = np.hstack(gf.data.flatten() for gf in deg_vecs)
+        vec = np.hstack([gf.data.flatten() for gf in deg_vecs])
     else:
-        vec = np.hstack(bgf[bl].data.flatten() for bl in bgf.indices)
+        vec = np.hstack([bgf[bl].data.flatten() for bl in bgf.indices])
     return vec
 
 
@@ -72,6 +72,117 @@ def _vec_to_bgf(vec, bgf, deg_shells=None):
             start = end
     return G
 
+def _broyden_update_general(it, broyler, general_params, deg_shells, F_freq, F_freq_previous):
+    """
+    calculates the broyden update of G0 using the algorithm presented in:
+    doi.org/10.1103/PhysRevB.80.125125 (Rok Zitko) &
+    doi.org/10.1103/PhysRevB.38.12807 (D.D. Johnson)
+
+    optimize function to find roots: F(G0)=dmft_step(G0) - G0 = 0
+    where dmft_step gives back the normal defined G0=inverse(Gloc^-1 - Sigma)
+
+    Parameters
+    ----------
+    it : int
+        iteration number
+    broyler: dict
+        dict containing the broyden variables
+    general_paramters: general params dict
+
+    Returns
+    -------
+    """
+    #alpha = general_params['g0_mix']
+    alpha = general_params['mix_greed']
+    mpi.report(f"Calling broyden step")
+    # hard code w_0
+    w_0 = 0.01
+
+    F_broyden_update = F_freq.copy()
+
+    # build here leg compression
+    if type(F_freq.mesh) is MeshImFreq and 'n_l' in general_params:
+        F = legendre_filter.apply(make_gf_from_fourier(F_freq), order=general_params['n_l'] )
+        F_prev = legendre_filter.apply(make_gf_from_fourier(F_freq_previous), order=general_params['n_l'] )
+    else:
+        F = F_freq.copy()
+        F_prev = F_freq_previous.copy()
+
+    # if this is the first time broyden update is called (it==2)
+    # store init F first
+    if it == 2:
+        # V holds the F as 1d numpy vectors
+        broyler['V'].append(_bgf_to_vec(F_prev, deg_shells))
+        # F = dmft_step_F - V[-1]
+        broyler['F'].append(_bgf_to_vec(F, deg_shells)-broyler['V'][-1])
+        # for the second iteration the broyden vec corresponds to simple linear mixing with alpha
+        broyden_vec = np.zeros(broyler['V'][0].shape[0],dtype='complex')
+
+    # for all other iteration calc V_mp1 = V[-1] + alpha * F[-1] - broyden_vec
+    # broyden vec is sum(n=1 to it-1) gamma_m_n U^n
+    # gamma_m_n = sum(k=1 to it-1)  c_k^m beta_k_n^m
+    # gamma_m_n is a number for each iteration and U^n is of dim F for each iteration
+    else:
+        # get size of broyden update vector
+        dim = broyler['V'][0].shape[0]
+        broyden_vec = np.zeros(dim,dtype='complex')
+
+        # define m as it-1-1 (last minus for idx starting at 0)
+        m = it-2
+
+        # update broyden input params
+        broyler['F'].append(_bgf_to_vec(F, deg_shells)-broyler['V'][-1])
+        norm_F = np.linalg.norm(broyler['F'][-1]-broyler['F'][-2])
+        print('broyden norm: {:.3f}'.format(norm_F))
+        # dF is normed differences between last two functions
+        broyler['dF'].append( (broyler['F'][-1]-broyler['F'][-2])/norm_F )
+        # dV the normed difference between the two last input F
+        broyler['dV'].append( (broyler['V'][-1] - broyler['V'][-2])/norm_F )
+
+        # now build broyden correction vector
+
+        #only keep last m iterations
+        mem_iter = general_params['broy_max_it']-1
+        start = 0
+        mat_dim = m
+        if m > mem_iter and not general_params['broy_max_it'] == -1:
+            for n in range(0, m-mem_iter):
+                start += 1
+                mat_dim -= 1
+
+        # first create beta_m
+        A = np.zeros((mat_dim,mat_dim),dtype='complex')
+        gamma = np.zeros(mat_dim,dtype='complex')
+        for k_i in range(start,m):
+            for n_i in range(start,m):
+                A[k_i-start,n_i-start] = np.dot(broyler['dF'][n_i].conjugate().transpose(),broyler['dF'][k_i])
+                if n_i == k_i:
+                    A[k_i-start,n_i-start] += w_0**2
+        beta_m = np.linalg.inv(A)
+        for n_i in range(start,m):
+            U_n = alpha * broyler['dF'][n_i] + broyler['dV'][n_i]
+
+            # construct gamma
+            for k_i in range(start,m):
+                c_k = np.dot(broyler['dF'][k_i].conjugate().transpose(),broyler['F'][-1])
+                gamma[n_i-start] += c_k*beta_m[k_i-start,n_i-start]
+            broyden_vec += gamma[n_i-start] * U_n
+
+    # update input F
+    V_mp1 = broyler['V'][-1] + alpha * broyler['F'][-1] - broyden_vec
+    broyler['V'].append(V_mp1)
+
+    # convert Gl back to F_freq
+    if type(F_freq.mesh) is MeshImFreq and 'n_l' in general_params:
+        F_l_update = _vec_to_bgf(broyler['V'][-1], F, deg_shells)
+        for block, g in F_l_update:
+            g.enforce_discontinuity(np.identity(g.target_shape[0]))
+            F_broyden_update[block].set_from_legendre(g)
+
+    else:
+        F_broyden_update << _vec_to_bgf(broyler['V'][-1], F, deg_shells)
+
+    return F_broyden_update, broyler
 
 def _broyden_update(it, broyler, general_params, deg_shells, G0_freq, G0_freq_previous):
     """
@@ -207,20 +318,214 @@ def mix_g0(solver, general_params, icrsh, archive, G0_freq_previous, it, deg_she
 
     return solver
 
+def mix_general(general_params, icrsh, solver, F_freq_previous, F_type, deg_shell, it, archive):
+    mix_greed = general_params['mix_greed']
+    mix_type = general_params['mix_type']
+
+    if F_type not in ['Gimp', 'G0', 'Sigma']:
+        raise ValueError(f"You are trying to mix the quantity '{F_type}', allowed values are: 'Gimp', 'G0', 'Sigma'")
+
+    def _load_F_solver():
+        if F_type == 'G0':
+            F_freq = solver.G0_freq
+        elif F_type == 'Gimp':
+            F_freq = solver.G_freq
+        elif F_type == 'Sigma':
+            F_freq = solver.Sigma_freq
+        
+        return F_freq
+    
+    def _save_to_solver():
+        if F_type == 'G0':
+            solver.G0_freq << mpi.bcast(solver.G0_freq)
+        elif F_type == 'Gimp':
+            solver.G_freq << mpi.bcast(solver.G_freq)
+        elif F_type == 'Sigma':
+            solver.Sigma_freq << mpi.bcast(solver.Sigma_freq)
+
+    
+
+    if mix_greed < 1.0 and mpi.is_master_node():
+        if mix_type == 'linear':
+            print(f'Linear mixing {F_type} with previous iteration by factor {mix_greed:.3f}\n')
+            F_freq = _load_F_solver()
+            F_freq <<  (mix_greed * F_freq + (1-mix_greed) * F_freq_previous)
+
+        elif mix_type == 'broyden':
+            print(f'Broyden mixing {F_type} with previous iteration by factor {mix_greed:.3f}\n')
+            mpi.report('\n############\n!!!! WARNING !!!! broyden mixing is still in early testing stage ! Use with caution.\n############\n')
+            # TODO implement broyden mixing for Sigma
+
+            broyler = archive['DMFT_results']['broyler']
+            F_freq = _load_F_solver()
+
+            BroylerObj = BroylerClass(broyler)
+            F_update = BroylerObj.broyden_step(it, icrsh, general_params, F_freq, F_freq_previous)
+            
+            F_freq << F_update
+            archive['DMFT_results']['broyler'] = BroylerObj.broyler_to_dict()
+
+
+
+    
+    # IMPORTANT!!!: the broadcast must be called outside of the MPI master node to avoid deadlocks!
+    _save_to_solver()
+        
+
+    return solver
+
+class BroylerClass:
+
+    def __init__(self, broyler_list):
+        self.n_inequiv_shells = len(broyler_list)
+        self.broy_max_it = broyler_list[0]['broy_max_it'] 
+        self.deg_shells = [broyler_list[icrsh]['deg_shell'] for icrsh in range(self.n_inequiv_shells)] 
+        self.mu =  [deque( broyler_list[icrsh]['mu'],  maxlen = self.broy_max_it ) for icrsh in range(self.n_inequiv_shells)]
+        self.V  =  [deque( broyler_list[icrsh]['V'] ,  maxlen = self.broy_max_it ) for icrsh in range(self.n_inequiv_shells)]
+        self.dV =  [deque( broyler_list[icrsh]['dV'],  maxlen = self.broy_max_it ) for icrsh in range(self.n_inequiv_shells)]
+        self.F  =  [deque( broyler_list[icrsh]['F'] ,  maxlen = self.broy_max_it ) for icrsh in range(self.n_inequiv_shells)]
+        self.dF =  [deque( broyler_list[icrsh]['dF'],  maxlen = self.broy_max_it ) for icrsh in range(self.n_inequiv_shells)]
+
+    def broyler_to_dict(self):
+        broyler_list_output = []
+        for icrsh in range(self.n_inequiv_shells):
+            broyler_list_output.append({
+                'mu': list(self.mu[icrsh]),
+                'V':  list(self.V[icrsh]),
+                'dV': list(self.dV[icrsh]),
+                'F':  list(self.F[icrsh]),
+                'dF': list(self.dF[icrsh]),
+                'broy_max_it': self.broy_max_it,
+                'deg_shell': self.deg_shells[icrsh],
+                })
+
+        return broyler_list_output
+
+    def broyden_step(self, it, icrsh, general_params, F_freq, F_freq_previous):
+        """
+        calculates the broyden update of G0 using the algorithm presented in:
+        doi.org/10.1103/PhysRevB.80.125125 (Rok Zitko) &
+        doi.org/10.1103/PhysRevB.38.12807 (D.D. Johnson)
+
+        optimize function to find roots: F(G0)=dmft_step(G0) - G0 = 0
+        where dmft_step gives back the normal defined G0=inverse(Gloc^-1 - Sigma)
+
+        Parameters
+        ----------
+        it : int
+            iteration number
+        broyler: dict
+            dict containing the broyden variables
+        general_paramters: general params dict
+
+        Returns
+        -------
+        """
+        alpha = general_params['mix_greed']
+        deg_shells = self.deg_shells[icrsh]
+
+
+        mpi.report(f"Object method: broyden step")
+        # hard code w_0
+        w_0 = 0.01
+
+        F_broyden_update = F_freq.copy()
+
+        # build here leg compression
+        if type(F_freq.mesh) is MeshImFreq and 'n_l' in general_params:
+            F = legendre_filter.apply(make_gf_from_fourier(F_freq), order=general_params['n_l'] )
+            F_prev = legendre_filter.apply(make_gf_from_fourier(F_freq_previous), order=general_params['n_l'] )
+        else:
+            F = F_freq.copy()
+            F_prev = F_freq_previous.copy()
+
+        # if this is the first time broyden update is called (it==2)
+        # store init F first
+        if it == 2:
+            # V holds the F as 1d numpy vectors
+            self.V[icrsh].append(_bgf_to_vec(F_prev, deg_shells))
+            # F = dmft_step_F - V[-1]
+            self.F[icrsh].append(_bgf_to_vec(F, deg_shells)-self.V[icrsh][-1])
+            # for the second iteration the broyden vec corresponds to simple linear mixing with alpha
+            broyden_vec = np.zeros(self.V[icrsh][0].shape[0],dtype='complex')
+
+        # for all other iteration calc V_mp1 = V[-1] + alpha * F[-1] - broyden_vec
+        # broyden vec is sum(n=1 to it-1) gamma_m_n U^n
+        # gamma_m_n = sum(k=1 to it-1)  c_k^m beta_k_n^m
+        # gamma_m_n is a number for each iteration and U^n is of dim F for each iteration
+        else:
+            # get size of broyden update vector
+            dim = self.V[icrsh][0].shape[0]
+            broyden_vec = np.zeros(dim,dtype='complex')
+
+            # define m as it-1-1 (last minus for idx starting at 0)
+            m = it-2
+
+            # update broyden input params
+            self.F[icrsh].append(_bgf_to_vec(F, deg_shells)-self.V[icrsh][-1])
+            norm_F = np.linalg.norm(self.F[icrsh][-1]-self.F[icrsh][-2])
+            print('broyden norm: {:.3f}'.format(norm_F))
+            # dF is normed differences between last two functions
+            self.dF[icrsh].append( (self.F[icrsh][-1]-self.F[icrsh][-2])/norm_F )
+            # dV the normed difference between the two last input F
+            self.dV[icrsh].append( (self.V[icrsh][-1] - self.V[icrsh][-2])/norm_F )
+
+            # now build broyden correction vector
+
+            #only keep last m iterations
+            mem_iter = self.broy_max_it-1
+            start = 0
+            mat_dim = min(self.broy_max_it, m)
+
+            # first create beta_m
+            A = np.zeros((mat_dim,mat_dim),dtype='complex')
+            gamma = np.zeros(mat_dim,dtype='complex')
+            for k_i in range(start,mat_dim):
+                for n_i in range(start,mat_dim):
+                    A[k_i-start,n_i-start] = np.dot(self.dF[icrsh][n_i].conjugate().transpose(),self.dF[icrsh][k_i])
+                    if n_i == k_i:
+                        A[k_i-start,n_i-start] += w_0**2
+            beta_m = np.linalg.inv(A)
+            for n_i in range(start,mat_dim):
+                U_n = alpha * self.dF[icrsh][n_i] + self.dV[icrsh][n_i]
+
+                # construct gamma
+                for k_i in range(start,mat_dim):
+                    c_k = np.dot(self.dF[icrsh][k_i].conjugate().transpose(),self.F[icrsh][-1])
+                    gamma[n_i-start] += c_k*beta_m[k_i-start,n_i-start]
+                broyden_vec += gamma[n_i-start] * U_n
+
+        # update input F
+        V_mp1 = self.V[icrsh][-1] + alpha * self.F[icrsh][-1] - broyden_vec
+        self.V[icrsh].append(V_mp1)
+
+        # convert Gl back to F_freq
+        if type(F_freq.mesh) is MeshImFreq and 'n_l' in general_params:
+            F_l_update = _vec_to_bgf(self.V[icrsh][-1], F, deg_shells)
+            for block, g in F_l_update:
+                g.enforce_discontinuity(np.identity(g.target_shape[0]))
+                F_broyden_update[block].set_from_legendre(g)
+
+        else:
+            F_broyden_update << _vec_to_bgf(self.V[icrsh][-1], F, deg_shells)
+
+        return F_broyden_update
+
+
+        
+
+
 
 def mix_sigma(general_params, n_inequiv_shells, solvers, Sigma_freq_previous):
-    if general_params['sigma_mix'] < 1.0 and mpi.is_master_node():
-        print('mixing sigma with previous iteration by factor {:.3f}\n'.format(general_params['sigma_mix']))
+    if general_params['mix_greed'] < 1.0 and mpi.is_master_node():
+        print('mixing sigma with previous iteration by factor {:.3f}\n'.format(general_params['mix_greed']))
         for icrsh in range(n_inequiv_shells):
-            solvers[icrsh].Sigma_freq << (general_params['sigma_mix'] * solvers[icrsh].Sigma_freq
-                                        + (1-general_params['sigma_mix']) * Sigma_freq_previous[icrsh])
-
+            solvers[icrsh].Sigma_freq << (general_params['mix_greed'] * solvers[icrsh].Sigma_freq
+                                        + (1-general_params['mix_greed']) * Sigma_freq_previous[icrsh])
     for icrsh in range(n_inequiv_shells):
         solvers[icrsh].Sigma_freq << mpi.bcast(solvers[icrsh].Sigma_freq)
 
     return solvers
-
-
 def init_cpa(sum_k, solvers, general_params):
     # initialize cpa_G_time, cpa_G0_freq; extract cpa_G_loc
     cpa_G_time = sum_k.block_structure.create_gf(ish=0, gf_function=Gf, space='solver',

--- a/python/solid_dmft/read_config.py
+++ b/python/solid_dmft/read_config.py
@@ -564,7 +564,10 @@ PROPERTIES_PARAMS = {'general': {'seedname': {'used': True},
                                  'afm_order': {'converter': BOOL_PARSER,
                                                'used': lambda params: params['general']['magnetic'],
                                                'default': False},
-                                 
+                                               
+                                 'update_mu_each_imp': {'converter': BOOL_PARSER,
+                                              'used': True, 'default': False},
+                                              
                                  'mix_quantity': {'converter': lambda s: list(map(str, s.split(','))),
                                             'used': True,
                                             'default': []},
@@ -578,16 +581,14 @@ PROPERTIES_PARAMS = {'general': {'seedname': {'used': True},
                                  'broy_max_it': {'converter': int, 'valid for': lambda x, _: x >= 1 or x==-1 ,
                                                 'used': True, 'default': 2},
                                                 
-                                 'sigma_mix': {'converter': float,
-                                               'valid for': lambda x, params: x >= 0 and (np.isclose(params['general']['g0_mix'], 1)
-                                                                                         or np.isclose(x, 1)),
-                                               'used': True, 'default': 1.0},
-
-                                 'g0_mix': {'converter': float, 'valid for': lambda x, _: x >= 0,
-                                               'used': True, 'default': 1.0},
-
-                                 'g0_mix_type': {'valid for': lambda x, _: x in ('linear', 'broyden'),
-                                                'used': True, 'default': 'linear'},
+                                 #'sigma_mix': {'converter': float,
+                                 #              'valid for': lambda x, params: x > 0 and (np.isclose(params['general']['g0_mix'], 1)
+                                 #                                                        or np.isclose(x, 1)),
+                                 #              'used': True, 'default': 1.0},
+                                 #'g0_mix': {'converter': float, 'valid for': lambda x, _: x > 0,
+                                 #              'used': True, 'default': 1.0},
+                                 #'g0_mix_type': {'valid for': lambda x, _: x in ('linear', 'broyden'),
+                                 #              'used': True, 'default': 'linear'},
 
 
                                  'calc_energies': {'converter': BOOL_PARSER, 'used': True, 'default': False},


### PR DESCRIPTION
Refactored the mixing to bring in more consistency, now there is a single linear/broyden mixing scheme that can mix either the Sigma or the G0. 
There is a small difference at the bookeeping level for the broyden mixing from last implementation (the number of iterations was off by one for some reason) so in the current implementation broy_max_it = 7 is equivalent to the previous broy_max_it=8.
I also added a counter that gets written to the h5 achive which counts the CSC steps, this is to signal to quantum espresso how many mixing steps it should include in the DFT charge density mixing (separate PR for QE will arrive, at the moment this update is also compatible with the previous QE versions)

There is also an added flag which allows one to perform the G update every impurity iteration instead of computing all impurities and then updating. Overall this adds 4 flags in the read_config:

"""
                                 'update_mu_each_imp': {'converter': BOOL_PARSER,
                                              'used': True, 'default': False},

                                 'mix_quantity': {'converter': lambda s: list(map(str, s.split(','))),
                                            'used': True,
                                            'default': []},

                                 'mix_type': {'valid for': lambda x, _: x in ('linear', 'broyden'),
                                                'used': True, 'default': 'linear'},

                                 'mix_greed': {'converter': float, 'valid for': lambda x, _: x > 0,
                                               'used': True, 'default': 1.0},
""
which take place of the previous G0 and Sigma mixing related flags.

The code still needs a little bit of cleaning (removing commented out code and adding description of new flags in the read config)


