### PR TITLE
updates on gw embedding and ctseg solver interface

### DIFF
--- a/python/solid_dmft/dmft_tools/solvers/ctseg_interface.py
+++ b/python/solid_dmft/dmft_tools/solvers/ctseg_interface.py
@@ -92,7 +92,7 @@ class CTSEGInterface(AbstractDMFTSolver):
         self.triqs_solver.Delta_tau << self.Delta_time
 
         if self.general_params['h_int_type'][self.icrsh] == 'dyn_density_density':
-            mpi.report('add dynamic interaction from AIMBES')
+            mpi.report('\nAdding dynamic interaction from AIMBES.')
             # convert 4 idx tensor to two index tensor
             Uloc_dlr = self.gw_params['Uloc_dlr'][self.icrsh]['up']
             Uloc_dlr_2idx_prime = Gf(mesh=Uloc_dlr.mesh, target_shape=[Uloc_dlr.target_shape[0], Uloc_dlr.target_shape[1]])
@@ -101,6 +101,12 @@ class CTSEGInterface(AbstractDMFTSolver):
                 Uloc_dlr_idx = Uloc_dlr[coeff]
                 _, Uprime = reduce_4index_to_2index(Uloc_dlr_idx)
                 Uloc_dlr_2idx_prime[coeff] = Uprime
+
+            # extract w=0 limit for analytic Sigma_Hartree for the impurity
+            Uloc_w0_2idx_prime = make_gf_imfreq(Uloc_dlr_2idx_prime, n_iw=1)
+            self.Uw0_prime = Uloc_w0_2idx_prime.data[0].real
+            mpi.report('Screened interaction U(iw) at iw=0 w/o the shift of V_bare (density-density only): ')
+            mpi.report(self.Uw0_prime)
 
             # create full frequency objects
             Uloc_tau_2idx_prime = make_gf_imtime(Uloc_dlr_2idx_prime, n_tau=self.solver_params['n_tau_bosonic'])
@@ -176,10 +182,6 @@ class CTSEGInterface(AbstractDMFTSolver):
 
             return
 
-        # first print average sign
-        if mpi.is_master_node():
-            print('\nAverage sign: {}'.format(self.triqs_solver.results.average_sign))
-
         # get Delta_time from solver
         self.Delta_time << self.triqs_solver.Delta_tau
 
@@ -200,27 +202,44 @@ class CTSEGInterface(AbstractDMFTSolver):
         self.Sigma_Hartree_sumk = {}
         self.Sigma_moments = {}
         if mpi.is_master_node():
+            mpi.report('Evaluating static impurity self-energy analytically using interacting density from ctseg...\n'
+                       '(results will be used in the subsequent tail fitting or the crm dyson solver)')
             # get density density U tensor from solver
             U_dict = extract_U_dict2(self.h_int)
             # print("sum_k is" + self.sum_k.__repr__())
             norb = common.get_n_orbitals(self.sum_k)
             norb = norb[self.icrsh]['up']
             U_dd = dict_to_matrix(U_dict, gf_struct=self.sum_k.gf_struct_solver_list[self.icrsh])
-            # extract Uijij and Uijji terms
+            # extract Uijij (inter- and intra-orbital Coulomb) and Uijji (Hund's coupling) terms
+            # a) For static impurity problem, Us are the static screened interactions
+            # b) For dynamic impurity problem, Us are the bare interactions
             Uijij = U_dd[0:norb, norb : 2 * norb]
             Uijji = Uijij - U_dd[0:norb, 0:norb]
-            # and construct full Uijkl tensor
+            # and construct full Uijkl tensor for static interaction
             Uijkl = construct_Uijkl(Uijij, Uijji)
 
+            if self.general_params['h_int_type'][self.icrsh] == 'dyn_density_density':
+                # For dynamic impurity problems, separate Us are needed for the Hartree and exchange self-energy
+                # a) Hartree term is evaluated using the screened interactions at w=0
+                # b) Exchange term is evaluated using the bare interactions
+                Uijij += self.Uw0_prime
+                Uijji[:, :] = 0.0
+                Uw0_ijkl = construct_Uijkl(Uijij, Uijji)
+            else:
+                Uw0_ijkl = Uijkl
+
             # now calculated Hartree shift via
-            # \Sigma^0_{\alpha \beta} = \sum_{i j} n_{i j} \left( 2 U_{\alpha i \beta j} - U_{\alpha i j \beta} \right)
+            # \Sigma^0_{\alpha \beta} = \sum_{i j} n_{i j} \left( 2 Uw0_{\alpha i \beta j} - U_{\alpha i j \beta} \right)
             for block, norb in self.sum_k.gf_struct_sumk[self.icrsh]:
                 self.Sigma_Hartree_sumk[block] = np.zeros((norb, norb), dtype=float)
                 for iorb, jorb in product(range(norb), repeat=2):
                     for inner in range(norb):
-                        self.Sigma_Hartree_sumk[block][iorb, jorb] += self.orbital_occupations_sumk[block][inner, inner].real * (
-                            2 * Uijkl[iorb, inner, jorb, inner].real - Uijkl[iorb, inner, inner, jorb].real
-                        )
+                        # exchange diagram K
+                        self.Sigma_Hartree_sumk[block][iorb, jorb] -= (
+                                self.orbital_occupations_sumk[block][inner, inner].real * (Uijkl[iorb, inner, inner, jorb].real))
+                        # Hartree (Coulomb) diagram J
+                        self.Sigma_Hartree_sumk[block][iorb, jorb] += (
+                                self.orbital_occupations_sumk[block][inner, inner].real * (2 * Uw0_ijkl[iorb, inner, jorb, inner].real))
 
             # convert to solver block structure
             self.Sigma_Hartree = self.sum_k.block_structure.convert_matrix(
@@ -253,11 +272,13 @@ class CTSEGInterface(AbstractDMFTSolver):
 
         # if measured in Legendre basis, get G_l from solver too
         if self.solver_params['legendre_fit']:
+            mpi.report('Self-energy post-processing algorithm: Legendre fitting')
             self.G_time_orig << self.triqs_solver.results.G_tau
             self.G_l << legendre_filter.apply(self.G_time, self.solver_params['n_l'])
             # get G_time, G_freq, Sigma_freq from G_l
             set_Gs_from_G_l()
         elif self.solver_params['perform_tail_fit']:
+            mpi.report('Self-energy post-processing algorithm: tail fitting with analytic static impurity self-energy')
             self.Sigma_freq = inverse(self.G0_freq) - inverse(self.G_freq)
             # without any degenerate shells we run the minimization for all blocks
             self.Sigma_freq, tail = self._fit_tail_window(
@@ -275,6 +296,7 @@ class CTSEGInterface(AbstractDMFTSolver):
 
         # if improved estimators are turned on calc Sigma from F_tau, otherwise:
         elif self.solver_params['improved_estimator']:
+            mpi.report('Self-energy post-processing algorithm: improved estimator')
             self.F_freq = self.G_freq.copy()
             self.F_freq << 0.0
             self.F_time = self.G_time.copy()
@@ -283,6 +305,7 @@ class CTSEGInterface(AbstractDMFTSolver):
             if mpi.is_master_node():
                 for i, bl in enumerate(self.F_freq.indices):
                     self.F_freq[bl] << Fourier(self.triqs_solver.results.F_tau[bl], F_known_moments[i])
+                # TODO CNY: remove it once tail fitting is activated
                 # fit tail of improved estimator and G_freq
                 self.F_freq << self._gf_fit_tail_fraction(self.F_freq, fraction=0.9, replace=0.5, known_moments=F_known_moments)
                 self.G_freq << self._gf_fit_tail_fraction(self.G_freq, fraction=0.9, replace=0.5, known_moments=Gf_known_moments)
@@ -295,6 +318,7 @@ class CTSEGInterface(AbstractDMFTSolver):
 
         # should this be moved to abstract class?
         elif self.solver_params['crm_dyson_solver']:
+            mpi.report('Self-energy post-processing algorithm: crm dyson solver')
             from triqs.gf.dlr_crm_dyson_solver import minimize_dyson
 
             mpi.report('\nCRM Dyson solver to extract Σ impurity\n')

--- a/python/solid_dmft/gw_embedding/bdft_converter.py
+++ b/python/solid_dmft/gw_embedding/bdft_converter.py
@@ -181,7 +181,12 @@ def tail_fit_g_weiss(g_weiss_wsIab, ir_kernel, gw_data, wmax_imp=None, eps_imp=N
 
 def bath_fitting(delta_wsIab, iw_mesh, Np=5):
     mpi.report(f"Bath fitting for hybridization with nbath/impurity orbital = {Np}")
-    from adapol import hybfit
+    try:
+        from adapol import hybfit
+    except ImportError:
+        raise ImportError("bath fitting requires the adapol package (https://github.com/flatironinstitute/adapol). \n"
+                          "Please ensure that it is installed. ")
+
     nspin, nImp = delta_wsIab.shape[1:3]
     error = -1
     for s in np.arange(nspin):

--- a/python/solid_dmft/gw_embedding/gw_flow.py
+++ b/python/solid_dmft/gw_embedding/gw_flow.py
@@ -55,7 +55,7 @@ from solid_dmft.version import solid_dmft_hash
 from solid_dmft.version import version as solid_dmft_version
 from solid_dmft.dmft_tools import formatter
 from solid_dmft.dmft_tools import results_to_archive
-from solid_dmft.dmft_tools.solver import SolverStructure
+from solid_dmft.dmft_tools.solver import create_solver
 from solid_dmft.dmft_tools import interaction_hamiltonian
 from solid_dmft.dmft_cycle import _extract_quantity_per_inequiv, _determine_block_structure
 from solid_dmft.dmft_tools import greens_functions_mixer as gf_mixer
@@ -360,10 +360,18 @@ def embedding_driver(general_params, solver_params, gw_params, advanced_params):
                                  sumk.n_inequiv_shells,
                                  max(gw_params['n_orb']),max(gw_params['n_orb'])),dtype=complex)
 
-    for ish in range(sumk.n_inequiv_shells):
+    for icrsh in range(sumk.n_inequiv_shells):
         # Construct the Solver instances
-        solvers[ish] = SolverStructure(general_params, solver_params[map_imp_solver[ish]],
-                                       gw_params, advanced_params, sumk, ish, h_int[ish])
+        mpi.report("Creating solver with new interface")
+        solvers[icrsh] = create_solver(general_params=general_params,
+                                       solver_params=solver_params[map_imp_solver[icrsh]],
+                                       gw_params=gw_params,
+                                       advanced_params=advanced_params,
+                                       sum_k=sumk,
+                                       h_int=h_int[icrsh],
+                                       icrsh=icrsh,
+                                       iteration_offset=iteration,
+                                       deg_orbs_ftps=None)
 
     # init local density matrices for observables
     density_tot = 0.0

--- a/python/solid_dmft/io_tools/default.toml
+++ b/python/solid_dmft/io_tools/default.toml
@@ -197,6 +197,8 @@ h5_file = "<none>"
 use_rot = false
 it_1e = 0
 it_2e = 0
+delta_calc_type = "tail_fit"
+delta_bath_fit = false
 
 [advanced]
 dc_factor = "<none>"

--- a/python/solid_dmft/io_tools/documentation.txt
+++ b/python/solid_dmft/io_tools/documentation.txt
@@ -354,20 +354,20 @@ max_time : int, default = -1
         maximum amount the solver is allowed to spend in each iteration
 measure_G_tau : bool, default = True
         should the solver measure G(tau)?
-measure_nnt : boold, default = False
+measure_nn_tau : boold, default = False
         measure two particle density-density correlation function (suszeptibility)
 measure_pert_order : bool, default = False
         measure perturbation order histograms: triqs.github.io/cthyb/latest/guide/perturbation_order_notebook.html.
         The result is stored in the h5 archive under 'DMFT_results' at every iteration
         in the subgroups 'pert_order_imp_X' and 'pert_order_total_imp_X'
-measure_statehist : bool, default = False
+measure_state_hist : bool, default = False
         measure state histogram, i.e. diagonal components of many body density matrix
 n_cycles_tot : int, mandatory
         total number of sweeps
 n_l : int, default = None
         number of Legendre coefficients.
         Needed if measure_G_l=True or legendre_fit=True
-n_tau_k : int, default = 10001
+n_tau_bosonic : int, default = 10001
         number imaginary time points for dynamic interactions
 n_warmup_cycles : int, mandatory
         number of warmup cycles before real measurement sets in

--- a/python/solid_dmft/io_tools/verify_input_params.py
+++ b/python/solid_dmft/io_tools/verify_input_params.py
@@ -112,7 +112,13 @@ def _verify_input_params_solver(params: FullConfig) -> None:
                        entry['improved_estimator'],
                        entry['perform_tail_fit']]
             if sum(tail_op) > 1:
-                raise ValueError('Only one of the options "crm_dyson_solver", "legendre_fit", "improved_estimator", and "perform_tail_fit" can be set to True.')
+                # allow improved_estimator + tail_fit
+                if sum([entry['improved_estimator'], entry['perform_tail_fit']]) < 2:
+                    raise ValueError(
+                        'Except "improved_estimator" + "perform_tail_fit", '
+                        'only one of the options "crm_dyson_solver", "legendre_fit", '
+                        '"improved_estimator", and "perform_tail_fit" can be set to True.'
+                    )
         if entry['type'] == 'cthyb':
             tail_op = [entry['crm_dyson_solver'],
                        entry['legendre_fit'],

--- a/python/solid_dmft/main.py
+++ b/python/solid_dmft/main.py
@@ -96,9 +96,22 @@ def run_dmft(params, config_file_name=None):
     elif general_params['gw_embedding']:
         from solid_dmft.gw_embedding.gw_flow import embedding_driver
         if mpi.is_master_node():
+            # Checks for h5 file
+            if not os.path.exists(general_params['seedname']+'.h5'):
+                raise FileNotFoundError('Input h5 file not found')
+
             # Creates output directory if it does not exist
             if not os.path.exists(general_params['jobname']):
                 os.makedirs(general_params['jobname'])
+
+            # Copies h5 archive to subfolder if it is not there
+            h5_name = general_params['seedname']+'.h5'
+            if not os.path.isfile(general_params['jobname']+'/'+os.path.basename(h5_name)):
+                shutil.copyfile(h5_name, general_params['jobname']+'/'+os.path.basename(h5_name))
+
+            # Copies config file to subfolder
+            if config_file_name is not None:
+                shutil.copyfile(config_file_name, general_params['jobname']+'/'+os.path.basename(config_file_name))
         mpi.barrier()
         # run GW embedding
         embedding_driver(general_params, solver_params, gw_params, advanced_params)


### PR DESCRIPTION
The PR contains several updates regarding gw embedding and the interface of ctseg solver. 

On the `ct-seg` interface: 
1. Fix the initialization problem of `D0_tau` for ct-seg when `enforce_off_diag = false`
2. Analytic evaluation for `Sigma_Hartree` for ctseg w/ retarded interactions 
3. Enable `improved_estimator` and `perform_tail_fit` at the same time

On gw embedding: 
1. Refactoring the process of extracting  the hybridization and `Hloc_0` for a given fermions Weiss field 
2. Replace `dummy_sumk` by `SumkDFT` for proper block_structure detection and orbital symmetrization 