### PR TITLE
update Ce2O3 tutorial toml file

### DIFF
--- a/doc/tutorials/Ce2O3_csc_w90/dmft_config.toml
+++ b/doc/tutorials/Ce2O3_csc_w90/dmft_config.toml
@@ -11,9 +11,11 @@ n_iter_dmft_first = 2
 n_iter_dmft_per = 1
 n_iter_dmft = 5
 
+enforce_off_diag = false
 block_threshold = 1e-03
 
 h_int_type = "density_density"
+h_int_basis = "qe"
 U = 6.46
 J = 0.46
 beta = 10


### PR DESCRIPTION
Hi, 

In this PR, I update the input toml file for the Ce2O3 tutorial.

In the updated toml file,
`enforce_off_diag = false`
`h_int_basis = "qe"`  
are added. 

The first line was added because the default value of that tag is set to `true`, and in this tutorial, we aimed to avoid that for affordable computational time. 
The second line was added because, when this tutorial was created, the tag `h_int_basis` did not exist in older version. Now, we set it to `"qe"` to ensure the correct orbital order, as intended in the tutorial.


Thanks!
Ina