### PR TITLE
Missing imports in `_ctseg_postprocessing`

### DIFF
--- a/python/solid_dmft/dmft_tools/solver.py
+++ b/python/solid_dmft/dmft_tools/solver.py
@@ -30,12 +30,13 @@ from triqs.gf.tools import inverse, make_zero_tail
 from triqs.gf.descriptors import Fourier
 from triqs.operators import c_dag, c, Operator, util
 from triqs.operators.util.U_matrix import reduce_4index_to_2index
-from triqs.operators.util.extractors import block_matrix_from_op
+from triqs.operators.util.extractors import block_matrix_from_op, extract_U_dict2, dict_to_matrix
 import triqs.utility.mpi as mpi
 import itertools
 from h5 import HDFArchive
 
 from solid_dmft.io_tools.dict_to_h5 import prep_params_for_h5
+from solid_dmft.postprocessing.eval_U_cRPA_RESPACK import construct_Uijkl
 
 from . import legendre_filter
 from .matheval import MathExpr


### PR DESCRIPTION
A few functions used here are missing imports:

https://github.com/TRIQS/solid_dmft/blob/12b01d076e9c00fe86fab31aea8062d9e307326c/python/solid_dmft/dmft_tools/solver.py#L1392-L1401

This PR adds those imports, but I don't see a place to add tests since this depends on the ctseg external package.