### PR TITLE
Slurm support

### DIFF
--- a/python/solid_dmft/dft_managers/mpi_helpers.py
+++ b/python/solid_dmft/dft_managers/mpi_helpers.py
@@ -60,8 +60,8 @@ def create_hostfile(number_cores, cluster_name):
 
     hostnames = mpi.world.gather(socket.gethostname(), root=0)
     if cluster_name == 'slurm':
-        slurm_hostnames = [hostname.split('.')[0] for hostname in hostnames]  # TODO: please find a better solution
-        hostnames = slurm_hostnames
+        # SLURM nodefile requires short hostnames (strip domain suffix if FQDN is returned)
+        hostnames = [hostname.split('.')[0] for hostname in hostnames]
     if mpi.is_master_node():
         # create hostfile based on first number_cores ranks
         hosts = defaultdict(int)
@@ -153,12 +153,15 @@ def get_mpi_arguments(mpi_profile, mpi_exe, number_cores, dft_exe, hostfile):
                 '-np', str(number_cores), '-envlist', 'PATH'] + shlex.split(dft_exe)
 
     if mpi_profile == 'slurm':
-        return [
-            mpi_exe, '-n', str(number_cores), '--export=PATH',
-            '-N', os.getenv("SLURM_JOB_NUM_NODES"), '-A', os.getenv("SLURM_JOB_ACCOUNT"),
-            '-p', os.getenv("SLURM_JOB_PARTITION"), '-t', '05:00', #TODO: decide way to get time limit
-            '-w', f"./{hostfile}",
-        ] + shlex.split(dft_exe)
+        # Default to srun when using SLURM; can be overridden via dft.mpi_exe in the config
+        if os.path.basename(mpi_exe) == 'mpirun':
+            mpi_exe = 'srun'
+        # srun inherits the remaining time of the allocation automatically when -t is omitted
+        return [mpi_exe, '-n', str(number_cores), '--export=PATH',
+                '-N', os.getenv("SLURM_JOB_NUM_NODES"),
+                '-A', os.getenv("SLURM_JOB_ACCOUNT"),
+                '-p', os.getenv("SLURM_JOB_PARTITION"),
+                '-w', f"./{hostfile}"] + shlex.split(dft_exe)
 
     return None
 

--- a/python/solid_dmft/dft_managers/mpi_helpers.py
+++ b/python/solid_dmft/dft_managers/mpi_helpers.py
@@ -151,9 +151,10 @@ def get_mpi_arguments(mpi_profile, mpi_exe, number_cores, dft_exe, hostfile):
 
     if mpi_profile == 'slurm':
         return [
-            mpi_exe, '-w', hostfile, '-n', str(number_cores), '--export=PATH',
+            mpi_exe, '-n', str(number_cores), '--export=PATH',
             '-N', os.getenv("SLURM_JOB_NUM_NODES"), '-A', os.getenv("SLURM_JOB_ACCOUNT"),
-            '-p', os.getenv("SLURM_JOB_PARTITION")
+            '-p', os.getenv("SLURM_JOB_PARTITION"),
+            '-w', f"./{hostfile}",
         ] + shlex.split(dft_exe)
 
     return None

--- a/python/solid_dmft/dft_managers/mpi_helpers.py
+++ b/python/solid_dmft/dft_managers/mpi_helpers.py
@@ -153,7 +153,7 @@ def get_mpi_arguments(mpi_profile, mpi_exe, number_cores, dft_exe, hostfile):
         return [
             mpi_exe, '-n', str(number_cores), '--export=PATH',
             '-N', os.getenv("SLURM_JOB_NUM_NODES"), '-A', os.getenv("SLURM_JOB_ACCOUNT"),
-            '-p', os.getenv("SLURM_JOB_PARTITION"),
+            '-p', os.getenv("SLURM_JOB_PARTITION"), '-t', '05:00', #TODO: decide way to get time limit
             '-w', f"./{hostfile}",
         ] + shlex.split(dft_exe)
 

--- a/python/solid_dmft/dft_managers/mpi_helpers.py
+++ b/python/solid_dmft/dft_managers/mpi_helpers.py
@@ -68,6 +68,7 @@ def create_hostfile(number_cores, cluster_name):
         mask_hostfile = {'openmpi': '{} slots={}',  # OpenMPI format
                          'openmpi-intra': '{} slots={}',  # OpenMPI format
                          'mpich': '{}:{}',  # MPICH format
+                         'slurm': '{}', # SLURM format
                          }[cluster_name]
 
         hostfile = 'dft.hostfile'
@@ -147,6 +148,13 @@ def get_mpi_arguments(mpi_profile, mpi_exe, number_cores, dft_exe, hostfile):
     if mpi_profile == 'mpich':
         return [mpi_exe, '-launcher', 'ssh', '-hostfile', hostfile,
                 '-np', str(number_cores), '-envlist', 'PATH'] + shlex.split(dft_exe)
+
+    if mpi_profile == 'slurm':
+        return [
+            mpi_exe, '-w', hostfile, '-n', str(number_cores), '--export=PATH',
+            '-N', os.getenv("SLURM_JOB_NUM_NODES"), '-A', os.getenv("SLURM_JOB_ACCOUNT"),
+            '-p', os.getenv("SLURM_JOB_PARTITION")
+        ] + shlex.split(dft_exe)
 
     return None
 

--- a/python/solid_dmft/dft_managers/mpi_helpers.py
+++ b/python/solid_dmft/dft_managers/mpi_helpers.py
@@ -59,6 +59,9 @@ def create_hostfile(number_cores, cluster_name):
         return None
 
     hostnames = mpi.world.gather(socket.gethostname(), root=0)
+    if cluster_name == 'slurm':
+        slurm_hostnames = [hostname.split('.')[0] for hostname in hostnames]  # TODO: please find a better solution
+        hostnames = slurm_hostnames
     if mpi.is_master_node():
         # create hostfile based on first number_cores ranks
         hosts = defaultdict(int)

--- a/python/solid_dmft/io_tools/verify_input_params.py
+++ b/python/solid_dmft/io_tools/verify_input_params.py
@@ -72,7 +72,7 @@ def _verify_input_params_dft(params: FullConfig) -> None:
     if params['dft']['dft_code'] not in ('vasp', 'qe', None):
         raise ValueError(f'Invalid "dft.dft_code" = {params["dft"]["dft_code"]}.')
 
-    if params['dft']['mpi_env'] not in ('default', 'openmpi', 'openmpi-intra', 'mpich'):
+    if params['dft']['mpi_env'] not in ('default', 'openmpi', 'openmpi-intra', 'mpich', 'slurm'):
         raise ValueError(f'Invalid "dft.mpi_env" = {params["dft"]["mpi_env"]}.')
 
     if params['dft']['projector_type'] not in ('w90', 'plo'):


### PR DESCRIPTION
I have a user at ORNL's OLCF that has requested to use sold_dmft on one of our resources and I have had trouble making it run with the slurm workload manager. I made a few changes here that can help alleviate the problem, and make it "work," but there remains a problem I'm having where submitted sub-jobs are causing an MPI error where it causes an `MPI_ABORT` that may be beyond the scope of this software.

Overall, I think if you want to include slurm-only support out of the box there may need to be a switch or feature in place to divvy up tasks from the host MPI process and allocate to VASP/`dft_exe` accordingly. E.g. get all ranks up front running `solid_dmft` and when running `dft_exe` provide explicit rank mappings in some way.
Take this with a grain of salt, I don't know your codebase.

Let me know if you have thoughts or questions and I'll do my best to get back to you!
