### PR TITLE
Fixes for dftkit compatibility and old HF solver

### DIFF
--- a/Docker/github_ci_dockerfile
+++ b/Docker/github_ci_dockerfile
@@ -116,7 +116,7 @@ RUN cd /source && git clone -b unstable --depth 1 https://github.com/TRIQS/hubba
     && make -j$NCORES && ctest -j$NCORES && make install
 
 # Hartree-Fock solver
-RUN cd /source && git clone -b unstable --depth 1 https://github.com/TRIQS/hartree_fock.git \
+RUN cd /source && git clone -b 3.3.x --depth 1 https://github.com/TRIQS/hartree_fock.git \
     && cd hartree_fock && mkdir -p build && cd build \
     && cmake ../ \
     && make -j$NCORES && ctest -j$NCORES && make install

--- a/Docker/jenkins_ci_dockerfile
+++ b/Docker/jenkins_ci_dockerfile
@@ -20,7 +20,7 @@ RUN cd / && git clone -b unstable --depth 1 https://github.com/TRIQS/hubbardI.gi
     && make install
 
 # Hartree-Fock solver
-RUN cd / && git clone -b unstable --depth 1 https://github.com/TRIQS/hartree_fock.git hartree.src \
+RUN cd / && git clone -b 3.3.x --depth 1 https://github.com/TRIQS/hartree_fock.git hartree.src \
     && mkdir -p hartree.build && cd hartree.build \
     && cmake ../hartree.src \
     && make install

--- a/Docker/mpich_dockerfile
+++ b/Docker/mpich_dockerfile
@@ -171,8 +171,8 @@ RUN cd /source && git clone -b unstable --depth 1 https://github.com/TRIQS/hubba
     && cmake ../hubbardI.src -DCMAKE_INSTALL_PREFIX=/triqs \
     && make -j$NCORES && make -j$NCORES test && make install
 
-# hartree_fock
-RUN cd /source && git clone -b unstable --depth 1 https://github.com/TRIQS/hartree_fock.git hartree_fock.src \
+# hartree_fock, 3.3.x needs to be changed to unstable eventually
+RUN cd /source && git clone -b 3.3.x --depth 1 https://github.com/TRIQS/hartree_fock.git hartree_fock.src \
     && mkdir -p hartree_fock.build && cd hartree_fock.build \
     && cmake ../hartree_fock.src -DCMAKE_INSTALL_PREFIX=/triqs \
     && make -j$NCORES && ctest -j$NCORES && make install

--- a/Docker/mpich_dockerfile_vasp5
+++ b/Docker/mpich_dockerfile_vasp5
@@ -157,7 +157,7 @@ RUN cd /source && git clone -b unstable --depth 1 https://github.com/TRIQS/hubba
     && make -j2 && make -j2 test && make install
 
 # Hartree-Fock
-RUN cd /source && git clone -b unstable --depth 1 https://github.com/TRIQS/hartree_fock hartree.src \
+RUN cd /source && git clone -b 3.3.x --depth 1 https://github.com/TRIQS/hartree_fock hartree.src \
     && mkdir -p hartree.build && cd hartree.build \
     && cmake ../hartree.src -DCMAKE_INSTALL_PREFIX=/triqs \
     && make -j2 && make -j2 test && make install

--- a/Docker/openmpi_dockerfile
+++ b/Docker/openmpi_dockerfile
@@ -209,8 +209,8 @@ RUN cd /source && git clone -b unstable --depth 1 https://github.com/TRIQS/hubba
     && cmake ../hubbardI.src \
     && make -j$NCORES && ctest -j$NCORES && make install
 
-# hartree_fock
-RUN cd /source && git clone -b unstable --depth 1 https://github.com/TRIQS/hartree_fock.git hartree_fock.src \
+# hartree_fock, 3.3.x works, but eventually this needs to be moved to unstable
+RUN cd /source && git clone -b 3.3.x --depth 1 https://github.com/TRIQS/hartree_fock.git hartree_fock.src \
     && mkdir -p hartree_fock.build && cd hartree_fock.build \
     && cmake ../hartree_fock.src \
     && make -j$NCORES && ctest -j$NCORES && make install

--- a/python/solid_dmft/csc_flow.py
+++ b/python/solid_dmft/csc_flow.py
@@ -36,10 +36,11 @@ import numpy as np
 from h5 import HDFArchive
 import triqs.utility.mpi as mpi
 
-from triqs_dft_tools.converters.wannier90 import Wannier90Converter
-from triqs_dft_tools.converters.vasp import VaspConverter
-from triqs_dft_tools.converters.plovasp.vaspio import VaspData
-import triqs_dft_tools.converters.plovasp.converter as plo_converter
+from triqs_dftkit.wannier90 import Converter as Wannier90Converter
+from triqs_dftkit.vasp import Converter as VaspConverter
+from triqs_dftkit.vasp.plovasp.vaspio import VaspData
+import triqs_dftkit.vasp.plovasp.converter as plo_converter
+
 
 from solid_dmft.dmft_cycle import dmft_cycle
 from solid_dmft.dft_managers import vasp_manager as vasp

--- a/python/solid_dmft/dmft_tools/solvers/hartree_interface.py
+++ b/python/solid_dmft/dmft_tools/solvers/hartree_interface.py
@@ -60,10 +60,13 @@ class HartreeInterface(AbstractDMFTSolver):
         # Always initialize the solver with dc_U and dc_J equal to U and J and let the _interface_hartree_dc function
         # take care of changing the parameters
         gf_struct = self.sum_k.gf_struct_solver_list[self.icrsh]
+
         self.triqs_solver = hartree_solver(
             beta=self.general_params['beta'],
             gf_struct=gf_struct,
             n_iw=self.general_params['n_iw'],
+            #eps=self.solver_params.get('eps_dlr', 1e-13),  # these will need to be added for the new DLR interface of the Hartree solver unstable branch 
+            #w_max = self.solver_params.get("w_max", 30),
             force_real=self.solver_params['force_real'],
             symmetries=[self._make_spin_equal],
             dc_U=self.general_params['U'][self.icrsh],


### PR DESCRIPTION
Hey all,

I added some small minor fixes in order for the Dockerfile to compile and the tests to pass.

Main changes:
* moved converter imports in csc_flow.py to dftkit

* changed branch pointer of triqs/hartree_fock to 3.3.x, since unstable moved to dlr without a compatibility layer