### PR TITLE
Small fix for sigma initialization equivalent shells of different types

### DIFF
--- a/python/solid_dmft/dmft_tools/initial_self_energies.py
+++ b/python/solid_dmft/dmft_tools/initial_self_energies.py
@@ -521,7 +521,8 @@ def determine_dc_and_initial_sigma(general_params, gw_params, advanced_params, s
                            for iineq in range(sum_k.n_inequiv_shells)]
             for icrsh in range(sum_k.n_inequiv_shells):
                 dc_pot = sum_k.block_structure.convert_matrix(sum_k.dc_imp[sum_k.inequiv_to_corr[icrsh]],
-                                                               ish_from=icrsh,
+                                                               ish_from=sum_k.inequiv_to_corr[icrsh],
+                                                               ish_to =icrsh,
                                                                space_from='sumk', space_to='solver')
 
                 if (general_params['magnetic'] and general_params['magmom'] and sum_k.SO == 0):


### PR DESCRIPTION
Small bugfix which fixes an issue that appears whenever one has 2 or more equivalent shells of different size (so 2 equivalent 3d shells + 2 equivalent 2p shells for example)


Wondering if for the future this kind of stuff should be heavily tested, (testing dmft calculation with 1 single atom,2 atoms 1 equivalent shell, 4 atoms 2 types of equivalent shells of different character d/p, ...)