### PR TITLE
Modernize TRIQS imports and Gf mesh constructor kwargs

### DIFF
--- a/doc/tutorials/Ce2O3_csc_w90/tutorial.ipynb
+++ b/doc/tutorials/Ce2O3_csc_w90/tutorial.ipynb
@@ -11,7 +11,7 @@
     "import matplotlib.pyplot as plt\n",
     "import matplotlib.ticker as ticker\n",
     "\n",
-    "from triqs.gf import *\n",
+    "from triqs.gfs import *\n",
     "from h5 import HDFArchive"
    ]
   },

--- a/doc/tutorials/PrNiO3_csc_vasp_plo_cthyb/tutorial.ipynb
+++ b/doc/tutorials/PrNiO3_csc_vasp_plo_cthyb/tutorial.ipynb
@@ -11,7 +11,7 @@
     "import matplotlib.pyplot as plt\n",
     "\n",
     "from h5 import HDFArchive\n",
-    "from triqs.gf import BlockGf"
+    "from triqs.gfs import BlockGf"
    ]
   },
   {

--- a/python/solid_dmft/dmft_cycle.py
+++ b/python/solid_dmft/dmft_cycle.py
@@ -303,7 +303,7 @@ def dmft_cycle(general_params, solver_params, advanced_params, dft_params,
     if general_params['beta'] is not None:
         mpi.report('Running solid_dmft on imag-freq grid because "general.beta" specified\n')
         sumk_mesh = MeshImFreq(beta=general_params['beta'],
-                               S='Fermion',
+                               statistic='Fermion',
                                n_iw=general_params['n_iw'])
         broadening = None
     else:

--- a/python/solid_dmft/dmft_cycle.py
+++ b/python/solid_dmft/dmft_cycle.py
@@ -39,8 +39,8 @@ from triqs.version import version as triqs_version
 from h5 import HDFArchive
 import triqs.utility.mpi as mpi
 from triqs.operators import c_dag, c, Operator
-from triqs.gf import make_hermitian, fit_hermitian_tail, MeshReFreq, MeshImFreq, make_gf_from_fourier, iOmega_n
-from triqs.gf.tools import inverse, make_zero_tail
+from triqs.gfs import make_hermitian, fit_hermitian_tail, MeshReFreq, MeshImFreq, make_gf_from_fourier, iOmega_n
+from triqs.gfs.tools import inverse, make_zero_tail
 from triqs_dft_tools.sumk_dft import SumkDFT
 
 # own modules

--- a/python/solid_dmft/dmft_tools/convergence.py
+++ b/python/solid_dmft/dmft_tools/convergence.py
@@ -30,7 +30,7 @@ import numpy as np
 
 # triqs
 from h5 import HDFArchive
-from triqs.gf import MeshImFreq, MeshImTime, MeshReFreq, BlockGf
+from triqs.gfs import MeshImFreq, MeshImTime, MeshReFreq, BlockGf
 from solid_dmft.dmft_tools import common
 
 def _generate_header(general_params, sum_k):

--- a/python/solid_dmft/dmft_tools/greens_functions_mixer.py
+++ b/python/solid_dmft/dmft_tools/greens_functions_mixer.py
@@ -29,9 +29,9 @@ import numpy as np
 # triqs
 import triqs.utility.mpi as mpi
 from h5 import HDFArchive
-from triqs.gf import MeshImFreq, MeshImTime, Gf, make_gf_from_fourier
-from triqs.gf.descriptors import Fourier
-from triqs.gf.tools import inverse
+from triqs.gfs import MeshImFreq, MeshImTime, Gf, make_gf_from_fourier
+from triqs.gfs.descriptors import Fourier
+from triqs.gfs.tools import inverse
 
 from . import legendre_filter
 

--- a/python/solid_dmft/dmft_tools/initial_self_energies.py
+++ b/python/solid_dmft/dmft_tools/initial_self_energies.py
@@ -34,7 +34,7 @@ import numpy as np
 # triqs
 from h5 import HDFArchive
 import triqs.utility.mpi as mpi
-from triqs.gf import BlockGf, Gf, make_gf_imfreq, MeshDLRImFreq, make_gf_dlr, MeshReFreq
+from triqs.gfs import BlockGf, Gf, make_gf_imfreq, MeshDLRImFreq, make_gf_dlr, MeshReFreq
 import itertools
 
 def calculate_double_counting(sum_k, density_matrix, general_params, gw_params, advanced_params, solver_type_per_imp, G_loc_all=None):

--- a/python/solid_dmft/dmft_tools/interaction_hamiltonian.py
+++ b/python/solid_dmft/dmft_tools/interaction_hamiltonian.py
@@ -35,7 +35,7 @@ from itertools import product
 # triqs
 from h5 import HDFArchive
 import triqs.utility.mpi as mpi
-from triqs.gf import make_gf_imfreq
+from triqs.gfs import make_gf_imfreq
 from triqs.operators import util, n, c, c_dag, Operator
 from solid_dmft.dmft_tools import common
 

--- a/python/solid_dmft/dmft_tools/legendre_filter.py
+++ b/python/solid_dmft/dmft_tools/legendre_filter.py
@@ -24,8 +24,8 @@
 import numpy as np
 
 # triqs
-from triqs.gf import BlockGf
-from triqs.gf.tools import fit_legendre
+from triqs.gfs import BlockGf
+from triqs.gfs.tools import fit_legendre
 
 
 def apply(G_tau, order=100, G_l_cut=1e-19):

--- a/python/solid_dmft/dmft_tools/manipulate_chemical_potential.py
+++ b/python/solid_dmft/dmft_tools/manipulate_chemical_potential.py
@@ -32,7 +32,7 @@ import numpy as np
 
 import triqs.utility.mpi as mpi
 from h5 import HDFArchive
-from triqs.gf import BlockGf, GfImFreq, GfImTime, Fourier, MeshImFreq
+from triqs.gfs import BlockGf, GfImFreq, GfImTime, Fourier, MeshImFreq
 try:
     if mpi.is_master_node():
         from solid_dmft.postprocessing import maxent_gf_latt
@@ -95,7 +95,7 @@ def _initialize_lattice_gf(sum_k, general_params):
 
     Returns
     -------
-    gf_lattice_iw : triqs.gf.BlockGf
+    gf_lattice_iw : triqs.gfs.BlockGf
         trace of the lattice GF over all blocks, orbitals and spins in
         Matsubara frequency.
     g_betahalf : complex

--- a/python/solid_dmft/dmft_tools/observables.py
+++ b/python/solid_dmft/dmft_tools/observables.py
@@ -222,8 +222,8 @@ def add_dft_values_as_zeroth_iteration(observables, general_params, solver_type_
                     Z_per_orbital.extend( [1.0] * G_loc_all_dft[iineq][spin_channel].target_shape[0]  )
                 else:
                     # G(beta/2)
-                    mesh = MeshImTime(beta=general_params['beta'], S="Fermion",
-                                      n_max=general_params['n_tau'])
+                    mesh = MeshImTime(beta=general_params['beta'], statistic="Fermion",
+                                      n_tau=general_params['n_tau'])
                     G_time = Gf(mesh=mesh, indices=G_loc_all_dft[iineq][spin_channel].indices)
                     G_time << Fourier(G_loc_all_dft[iineq][spin_channel])
 

--- a/python/solid_dmft/dmft_tools/observables.py
+++ b/python/solid_dmft/dmft_tools/observables.py
@@ -32,9 +32,9 @@ import numpy as np
 # triqs
 import triqs.utility.mpi as mpi
 from h5 import HDFArchive
-from triqs.gf import Gf, MeshImTime
+from triqs.gfs import Gf, MeshImTime
 from triqs.atom_diag import trace_rho_op
-from triqs.gf.descriptors import Fourier
+from triqs.gfs.descriptors import Fourier
 from solid_dmft.dmft_tools import common
 
 def prep_observables(h5_archive, sum_k):

--- a/python/solid_dmft/dmft_tools/solvers/abstractdmftsolver.py
+++ b/python/solid_dmft/dmft_tools/solvers/abstractdmftsolver.py
@@ -28,7 +28,7 @@ abstract DMFT solver class for solid_dmft
 '''
 import numpy as np
 
-from triqs.gf import MeshImTime, MeshReTime, MeshReFreq, MeshLegendre, Gf, BlockGf
+from triqs.gfs import MeshImTime, MeshReTime, MeshReFreq, MeshLegendre, Gf, BlockGf
 from triqs.operators import Operator
 
 # import abc
@@ -250,7 +250,7 @@ class AbstractDMFTSolver(ABC):
         tail_barr : dict of arr
                     fitted tail of Sigma_iw
         """
-        from triqs.gf.gf_fnt import fit_hermitian_tail_on_window, replace_by_tail
+        from triqs.gfs.gf_fnt import fit_hermitian_tail_on_window, replace_by_tail
 
         # Define default tail quantities
         if fit_min_w is not None:

--- a/python/solid_dmft/dmft_tools/solvers/abstractdmftsolver.py
+++ b/python/solid_dmft/dmft_tools/solvers/abstractdmftsolver.py
@@ -111,7 +111,7 @@ class AbstractDMFTSolver(ABC):
         # create all ImTime instances
         self.n_tau = self.general_params['n_tau']
         self.G_time = self.sum_k.block_structure.create_gf(
-            ish=self.icrsh, gf_function=Gf, space='solver', mesh=MeshImTime(beta=self.sum_k.mesh.beta, S='Fermion', n_tau=self.n_tau)
+            ish=self.icrsh, gf_function=Gf, space='solver', mesh=MeshImTime(beta=self.sum_k.mesh.beta, statistic='Fermion', n_tau=self.n_tau)
         )
         # copy
         self.Delta_time = self.G_time.copy()
@@ -123,7 +123,7 @@ class AbstractDMFTSolver(ABC):
                 ish=self.icrsh,
                 gf_function=Gf,
                 space='solver',
-                mesh=MeshLegendre(beta=self.general_params['beta'], max_n=self.n_l, S='Fermion'),
+                mesh=MeshLegendre(beta=self.general_params['beta'], max_n=self.n_l, statistic='Fermion'),
             )
             # move original G_freq to G_freq_orig
             self.G_time_orig = self.G_time.copy()

--- a/python/solid_dmft/dmft_tools/solvers/cthyb_interface.py
+++ b/python/solid_dmft/dmft_tools/solvers/cthyb_interface.py
@@ -27,8 +27,8 @@
 cthyb solver class for solid_dmft
 '''
 import numpy as np
-from triqs.gf import MeshDLRImFreq, Gf, make_gf_imfreq, make_hermitian, fit_gf_dlr, make_gf_dlr_imtime
-from triqs.gf.tools import inverse
+from triqs.gfs import MeshDLRImFreq, Gf, make_gf_imfreq, make_hermitian, fit_gf_dlr, make_gf_dlr_imtime
+from triqs.gfs.tools import inverse
 import triqs.utility.mpi as mpi
 from h5 import HDFArchive
 
@@ -235,7 +235,7 @@ class CTHYBInterface(AbstractDMFTSolver):
                 # if tailfit has been used replace Sigma with the tail fitted Sigma from cthyb
                 self.Sigma_freq << self.triqs_solver.Sigma_iw
             elif self.solver_params['crm_dyson_solver']:
-                from triqs.gf.dlr_crm_dyson_solver import minimize_dyson
+                from triqs.gfs.dlr_crm_dyson_solver import minimize_dyson
 
                 mpi.report('\nCRM Dyson solver to extract Σ impurity\n')
                 # fit QMC G_tau to DLR

--- a/python/solid_dmft/dmft_tools/solvers/ctint_interface.py
+++ b/python/solid_dmft/dmft_tools/solvers/ctint_interface.py
@@ -28,9 +28,9 @@ ctint solver class for solid_dmft
 '''
 from itertools import product
 
-from triqs.gf import make_hermitian
-from triqs.gf.tools import inverse
-from triqs.gf.descriptors import Fourier
+from triqs.gfs import make_hermitian
+from triqs.gfs.tools import inverse
+from triqs.gfs.descriptors import Fourier
 import triqs.utility.mpi as mpi
 from h5 import HDFArchive
 

--- a/python/solid_dmft/dmft_tools/solvers/ctseg_interface.py
+++ b/python/solid_dmft/dmft_tools/solvers/ctseg_interface.py
@@ -29,9 +29,9 @@ ctseg solver class for solid_dmft
 import numpy as np
 from itertools import product
 
-from triqs.gf import MeshDLRImFreq, Gf, BlockGf, make_gf_imfreq, make_hermitian, make_gf_dlr, fit_gf_dlr, make_gf_dlr_imtime, make_gf_imtime
-from triqs.gf.tools import inverse, make_zero_tail
-from triqs.gf.descriptors import Fourier
+from triqs.gfs import MeshDLRImFreq, Gf, BlockGf, make_gf_imfreq, make_hermitian, make_gf_dlr, fit_gf_dlr, make_gf_dlr_imtime, make_gf_imtime
+from triqs.gfs.tools import inverse, make_zero_tail
+from triqs.gfs.descriptors import Fourier
 from triqs.operators.util.U_matrix import reduce_4index_to_2index
 import triqs.utility.mpi as mpi
 from h5 import HDFArchive
@@ -356,7 +356,7 @@ class CTSEGInterface(AbstractDMFTSolver):
         # should this be moved to abstract class?
         elif self.solver_params['crm_dyson_solver']:
             mpi.report('Self-energy post-processing algorithm: crm dyson solver')
-            from triqs.gf.dlr_crm_dyson_solver import minimize_dyson
+            from triqs.gfs.dlr_crm_dyson_solver import minimize_dyson
 
             mpi.report('\nCRM Dyson solver to extract Σ impurity\n')
             # fit QMC G_tau to DLR

--- a/python/solid_dmft/dmft_tools/solvers/ftps_interface.py
+++ b/python/solid_dmft/dmft_tools/solvers/ftps_interface.py
@@ -29,8 +29,8 @@ FTPS solver class for solid_dmft
 import numpy as np
 from itertools import product
 
-from triqs.gf import MeshReTime, Gf, Omega
-from triqs.gf.tools import inverse
+from triqs.gfs import MeshReTime, Gf, Omega
+from triqs.gfs.tools import inverse
 import triqs.utility.mpi as mpi
 from h5 import HDFArchive
 

--- a/python/solid_dmft/dmft_tools/solvers/hartree_interface.py
+++ b/python/solid_dmft/dmft_tools/solvers/hartree_interface.py
@@ -26,8 +26,8 @@
 '''
 hartree solver class for solid_dmft
 '''
-from triqs.gf import MeshReFreq, Gf
-from triqs.gf.descriptors import Fourier
+from triqs.gfs import MeshReFreq, Gf
+from triqs.gfs.descriptors import Fourier
 import triqs.utility.mpi as mpi
 
 # import of the abstract class

--- a/python/solid_dmft/dmft_tools/solvers/hubbardI_interface.py
+++ b/python/solid_dmft/dmft_tools/solvers/hubbardI_interface.py
@@ -26,7 +26,7 @@
 '''
 hubbardI solver class for solid_dmft
 '''
-from triqs.gf import MeshReFreq, Gf, make_hermitian
+from triqs.gfs import MeshReFreq, Gf, make_hermitian
 
 # import of the abstract class
 from solid_dmft.dmft_tools.solvers.abstractdmftsolver import AbstractDMFTSolver

--- a/python/solid_dmft/gw_embedding/bdft_converter.py
+++ b/python/solid_dmft/gw_embedding/bdft_converter.py
@@ -32,14 +32,14 @@ from scipy.constants import physical_constants
 
 from h5 import HDFArchive
 from triqs.utility import mpi
-from triqs.gf import (
+from triqs.gfs import (
     Gf,
     BlockGf,
     make_gf_dlr_imtime,
     make_gf_dlr,
     make_gf_dlr_imfreq,
 )
-from triqs.gf.meshes import MeshDLRImFreq, MeshDLRImTime
+from triqs.mesh import MeshDLRImFreq, MeshDLRImTime
 import itertools
 
 from solid_dmft.gw_embedding.iaft import IAFT

--- a/python/solid_dmft/gw_embedding/gw_flow.py
+++ b/python/solid_dmft/gw_embedding/gw_flow.py
@@ -32,7 +32,7 @@ import numpy as np
 
 from h5 import HDFArchive
 from triqs.utility import mpi
-from triqs.gf import (
+from triqs.gfs import (
     iOmega_n,
     inverse,
     fit_hermitian_tail,
@@ -46,7 +46,7 @@ from triqs.gf import (
 )
 from triqs.version import git_hash as triqs_hash
 from triqs.version import version as triqs_version
-from triqs.gf.meshes import MeshImFreq
+from triqs.mesh import MeshImFreq
 from triqs.operators import c_dag, c, Operator
 from triqs_dft_tools.block_structure import BlockStructure
 from triqs_dft_tools.sumk_dft import SumkDFT

--- a/python/solid_dmft/postprocessing/maxent_gf_imp.py
+++ b/python/solid_dmft/postprocessing/maxent_gf_imp.py
@@ -42,7 +42,7 @@ from triqs_maxent.alpha_meshes import LogAlphaMesh
 from triqs_maxent.logtaker import VerbosityFlags
 from h5 import HDFArchive
 from triqs.utility import mpi
-from triqs.gf import BlockGf
+from triqs.gfs import BlockGf
 
 
 def _read_h5(external_path, iteration):

--- a/python/solid_dmft/postprocessing/maxent_gf_latt.py
+++ b/python/solid_dmft/postprocessing/maxent_gf_latt.py
@@ -43,7 +43,7 @@ from triqs_maxent.alpha_meshes import LogAlphaMesh
 from triqs_dft_tools.sumk_dft import SumkDFT
 from h5 import HDFArchive
 from triqs.utility import mpi
-from triqs.gf import Gf, BlockGf
+from triqs.gfs import Gf, BlockGf
 
 
 def _read_h5(external_path, iteration):

--- a/python/solid_dmft/postprocessing/maxent_sigma.py
+++ b/python/solid_dmft/postprocessing/maxent_sigma.py
@@ -303,9 +303,9 @@ def main(external_path, iteration=None, continuator_type='inversion_sigmainf', m
 
     Returns
     -------
-    sigma_w : list of triqs.gf.BlockGf
+    sigma_w : list of triqs.gfs.BlockGf
         Sigma(omega) per inequivalent shell
-    g_aux_w : list of triqs.gf.BlockGf
+    g_aux_w : list of triqs.gfs.BlockGf
         G_aux(omega) per inequivalent shell
 
     Raises

--- a/python/solid_dmft/postprocessing/pade_sigma.py
+++ b/python/solid_dmft/postprocessing/pade_sigma.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from triqs.utility import mpi
 from h5 import HDFArchive
-from triqs.gf import Gf, MeshReFreq, BlockGf
+from triqs.gfs import Gf, MeshReFreq, BlockGf
 
 from solid_dmft.postprocessing.maxent_sigma import _read_h5
 
@@ -85,7 +85,7 @@ def main(external_path, n_w, w_min, w_max, n_iw, iteration=None, eta=0.0):
 
     Returns
     -------
-    sigma_w : list of triqs.gf.BlockGf
+    sigma_w : list of triqs.gfs.BlockGf
         Sigma(omega) per inequivalent shell
     """
 

--- a/python/solid_dmft/postprocessing/plot_correlated_bands.py
+++ b/python/solid_dmft/postprocessing/plot_correlated_bands.py
@@ -47,7 +47,7 @@ import skimage.measure
 from warnings import warn
 
 from h5 import HDFArchive
-from triqs.gf import BlockGf, MeshReFreq, Gf
+from triqs.gfs import BlockGf, MeshReFreq, Gf
 from triqs.lattice.utils import TB_from_wannier90, k_space_path
 from triqs_dft_tools.sumk_dft import SumkDFT
 

--- a/test/python/lno_cthyb_mag/test.py
+++ b/test/python/lno_cthyb_mag/test.py
@@ -1,7 +1,7 @@
 import sys
 import shutil
 
-from triqs.gf import *
+from triqs.gfs import *
 from triqs.utility.comparison_tests import assert_block_gfs_are_close
 from h5 import HDFArchive
 import triqs.utility.mpi as mpi

--- a/test/python/lno_hubbardI_mag/test.py
+++ b/test/python/lno_hubbardI_mag/test.py
@@ -1,7 +1,7 @@
 import sys
 import shutil
 
-from triqs.gf import *
+from triqs.gfs import *
 from triqs.utility.comparison_tests import assert_block_gfs_are_close
 from h5 import HDFArchive
 import triqs.utility.mpi as mpi

--- a/test/python/svo_cthyb_basic_tf/test.py
+++ b/test/python/svo_cthyb_basic_tf/test.py
@@ -1,7 +1,7 @@
 import sys
 import shutil
 
-from triqs.gf import *
+from triqs.gfs import *
 from triqs.utility.comparison_tests import assert_block_gfs_are_close, assert_arrays_are_close
 from h5 import HDFArchive
 import triqs.utility.mpi as mpi

--- a/test/python/svo_cthyb_crpa/test.py
+++ b/test/python/svo_cthyb_crpa/test.py
@@ -1,7 +1,7 @@
 import sys
 import shutil
 
-from triqs.gf import *
+from triqs.gfs import *
 from triqs.utility.comparison_tests import assert_block_gfs_are_close, assert_arrays_are_close
 from h5 import HDFArchive
 import triqs.utility.mpi as mpi

--- a/test/python/test_convergence.py
+++ b/test/python/test_convergence.py
@@ -30,8 +30,8 @@ class test_convergence(unittest.TestCase):
         beta = 10.0
         n_iw = 50
         n_tau = 6*n_iw + 1
-        self.iw_mesh = MeshImFreq(beta=beta, S="Fermion", n_max=n_iw)
-        self.tau_mesh = MeshImTime(beta=beta, S="Fermion", n_max=n_tau)
+        self.iw_mesh = MeshImFreq(beta=beta, statistic="Fermion", n_iw=n_iw)
+        self.tau_mesh = MeshImTime(beta=beta, statistic="Fermion", n_tau=n_tau)
         self.norb = 2
 
         self.G1_iw = Gf(mesh=self.iw_mesh, target_shape=(self.norb, self.norb))

--- a/test/python/test_convergence.py
+++ b/test/python/test_convergence.py
@@ -16,7 +16,7 @@
 # Authors: Alexander Hampel
 
 import numpy as np
-from triqs.gf import MeshImFreq, MeshImTime, iOmega_n, inverse, BlockGf, Gf, SemiCircular, make_gf_from_fourier
+from triqs.gfs import MeshImFreq, MeshImTime, iOmega_n, inverse, BlockGf, Gf, SemiCircular, make_gf_from_fourier
 from triqs.utility.comparison_tests import assert_arrays_are_close
 from solid_dmft.dmft_tools.convergence import max_G_diff
 

--- a/test/python/test_gw_embedding.py
+++ b/test/python/test_gw_embedding.py
@@ -20,7 +20,7 @@ import numpy as np
 from h5 import HDFArchive
 import unittest
 
-from triqs.gf import MeshDLRImFreq, Gf, BlockGf, make_gf_dlr, make_gf_imfreq, make_gf_dlr_imfreq
+from triqs.gfs import MeshDLRImFreq, Gf, BlockGf, make_gf_dlr, make_gf_imfreq, make_gf_dlr_imfreq
 
 from solid_dmft.gw_embedding.bdft_converter import convert_gw_output, calc_Sigma_DC_gw, calc_W_from_Gloc
 

--- a/test/python/test_observables.py
+++ b/test/python/test_observables.py
@@ -51,7 +51,7 @@ class test_observables(unittest.TestCase):
         general_params['solver_type'] = 'cthyb'
         general_params['n_tau'] = 10001
 
-        mesh_iw = MeshImFreq(beta=general_params['beta'], S='Fermion', n_iw = 1025)
+        mesh_iw = MeshImFreq(beta=general_params['beta'], statistic='Fermion', n_iw = 1025)
         gf_up = Gf(mesh=mesh_iw, target_shape=[1,1])
         gf_down = gf_up.copy()
         gf_up << SemiCircular(2, 0)
@@ -98,7 +98,7 @@ class test_observables(unittest.TestCase):
         general_params['solver_type'] = 'cthyb'
         general_params['n_tau'] = 10001
 
-        mesh_iw = MeshImFreq(beta=general_params['beta'], S='Fermion', n_iw = 1025)
+        mesh_iw = MeshImFreq(beta=general_params['beta'], statistic='Fermion', n_iw = 1025)
         gf_up_one_band = Gf(mesh=mesh_iw, target_shape=[1,1])
         gf_down_one_band = gf_up_one_band.copy()
         gf_up_one_band << SemiCircular(2, 1)
@@ -164,14 +164,14 @@ class test_observables(unittest.TestCase):
         shell_multiplicity = [4]
         E_bandcorr = 10.43
 
-        mesh_iw = MeshImFreq(beta=general_params['beta'], S='Fermion', n_iw = 1025)
+        mesh_iw = MeshImFreq(beta=general_params['beta'], statistic='Fermion', n_iw = 1025)
         gf_up = Gf(mesh=mesh_iw, target_shape=[1,1])
         gf_down = gf_up.copy()
         gf_up << SemiCircular(2, 0)
         gf_down << SemiCircular(1, 0)
         gf_iw = [BlockGf(name_list=('up_0', 'down_0'), block_list=(gf_up, gf_down), make_copies=True)]
 
-        mesh_tau = MeshImTime(beta=general_params['beta'], S='Fermion', n_tau = 10001)
+        mesh_tau = MeshImTime(beta=general_params['beta'], statistic='Fermion', n_tau = 10001)
         gf_imtime = Gf(mesh=mesh_tau, target_shape=[1,1])
         gf_tau = [BlockGf(name_list=('up_0', 'down_0'), block_list=(gf_imtime, gf_imtime), make_copies=True)]
         gf_tau[0] << Fourier(gf_iw[0])

--- a/test/python/test_observables.py
+++ b/test/python/test_observables.py
@@ -4,8 +4,8 @@
 Contains unit tests for observables.py
 """
 
-from triqs.gf import BlockGf, Gf, SemiCircular, MeshImFreq, MeshImTime
-from triqs.gf.descriptors import Fourier
+from triqs.gfs import BlockGf, Gf, SemiCircular, MeshImFreq, MeshImTime
+from triqs.gfs.descriptors import Fourier
 
 from solid_dmft.dmft_tools.observables import add_dft_values_as_zeroth_iteration, add_dmft_observables, _generate_header
 from helper import are_iterables_equal, Dummy


### PR DESCRIPTION
## Summary
- Replace `triqs.gf` imports with `triqs.gfs` across the codebase, tests, and tutorial notebooks.
- Switch Matsubara mesh construction to modern keyword arguments (`statistic`, `n_iw`, `n_tau`) for compatibility with current TRIQS.

## Test plan
- [ ] CI passes against current `triqs/unstable`
- [ ] Run the python test suite locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)