### PR TITLE
make HF solver in solid_dmft compatible with triqs 4.0.0

### DIFF
--- a/python/solid_dmft/dmft_tools/solvers/hartree_interface.py
+++ b/python/solid_dmft/dmft_tools/solvers/hartree_interface.py
@@ -26,7 +26,7 @@
 '''
 hartree solver class for solid_dmft
 '''
-from triqs.gfs import MeshReFreq, Gf
+from triqs.gfs import MeshReFreq, Gf, inverse, make_gf_dlr_imfreq, make_gf_imfreq, find_w_max
 from triqs.gfs.descriptors import Fourier
 import triqs.utility.mpi as mpi
 
@@ -61,12 +61,24 @@ class HartreeInterface(AbstractDMFTSolver):
         # take care of changing the parameters
         gf_struct = self.sum_k.gf_struct_solver_list[self.icrsh]
 
+        # The Hartree solver now stores its Green's functions on a DLR Matsubara mesh
+        # (triqs_hartree_fock commit c948fe7). solid_dmft still works with full Matsubara
+        # meshes for the lattice Green's function, so we bridge between the two with the
+        # triqs functions make_gf_dlr_imfreq / make_gf_imfreq / find_w_max (commit a43d8cc):
+        # the regular-mesh Weiss field G0 is sampled onto a DLR mesh in solve() and the
+        # solver's DLR outputs are converted back in postprocess(). These two attributes
+        # fully define that DLR mesh and are kept on the instance so they are available if
+        # the lattice Green's function is itself moved onto a DLR mesh in the future.
+        self.dlr_eps = self.solver_params['eps_dlr']
+        self.dlr_w_max = None  # set in solve() via find_w_max from the Weiss field G0
+
+        # w_max here is only a placeholder for the initial (empty) construction; the actual
+        # DLR mesh is built in solve() once the Weiss field is known.
         self.triqs_solver = hartree_solver(
             beta=self.general_params['beta'],
             gf_struct=gf_struct,
-            n_iw=self.general_params['n_iw'],
-            #eps=self.solver_params.get('eps_dlr', 1e-13),  # these will need to be added for the new DLR interface of the Hartree solver unstable branch 
-            #w_max = self.solver_params.get("w_max", 30),
+            w_max=1.0,
+            eps=self.dlr_eps,
             force_real=self.solver_params['force_real'],
             symmetries=[self._make_spin_equal],
             dc_U=self.general_params['U'][self.icrsh],
@@ -143,13 +155,66 @@ class HartreeInterface(AbstractDMFTSolver):
             ish=self.icrsh, gf_function=Gf, space='solver', mesh=MeshReFreq(n_w=self.n_w, window=self.general_params['w_range'])
         )
 
-    def solve(self, **kwargs):
-        # fill G0_freq from sum_k to solver
-        self.triqs_solver.G0_iw << self.G0_freq
+    def _largest_fitting_dlr_w_max(self, g):
+        # Largest DLR cutoff whose Matsubara nodes still fit inside the n_iw mesh of g.
+        # find_w_max(G0) is guaranteed to fit (G0 lives on the same mesh), so grow from
+        # there by 1.5x until make_gf_dlr_imfreq can no longer sample g.
+        w_max = find_w_max(self.G0_freq, self.dlr_eps)
+        trial = w_max * 1.5
+        while trial <= 200.0:
+            try:
+                make_gf_dlr_imfreq(g, trial, self.dlr_eps)
+            except RuntimeError:
+                break
+            w_max = trial
+            trial *= 1.5
+        return w_max
 
-        # Solve the impurity problem for icrsh shell
+    def _set_dlr_G0(self, w_max):
+        # Sample the regular-mesh Weiss field onto a DLR Matsubara mesh of cutoff w_max
+        # and hand it to the solver (G_iw is allocated on the same mesh for the solver).
+        self.triqs_solver.w_max = w_max
+        self.triqs_solver.G0_iw = make_gf_dlr_imfreq(self.G0_freq, w_max, self.dlr_eps)
+        self.triqs_solver.G_iw = self.triqs_solver.G0_iw.copy()
+
+    def solve(self, **kwargs):
+        # The DLR mesh must be sized to the impurity Green's function, not just the Weiss
+        # field G0: in Hartree-Fock the self energy is a constant matrix that shifts G's
+        # spectral weight away from G0, so a mesh sized to G0 alone under-resolves G (and
+        # hence its density). Sigma_HF is unknown before solving, and on the first iteration
+        # the seeded guess is zero (the Hartree DC is computed inside the solver), so we run
+        # a cheap estimate solve on a G0-sized mesh to obtain the actual (constant) Sigma_HF,
+        # build a guesstimate G from it, and size the real DLR mesh from that via find_w_max.
+        # The estimate solve overwrites Sigma_HF, so we restart the final solve from the
+        # original guess to leave the one_shot result unchanged.
+        sigma_hf_init = {bl: s.copy() for bl, s in self.triqs_solver.Sigma_HF.items()}
+
+        self._set_dlr_G0(find_w_max(self.G0_freq, self.dlr_eps))
+        self.triqs_solver.solve(h_int=self.h_int, **self.triqs_solver_params)
+        sigma_est = {bl: s.copy() for bl, s in self.triqs_solver.Sigma_HF.items()}
+
+        G_guess = self.G0_freq.copy()
+        for bl, g in G_guess:
+            g << inverse(inverse(self.G0_freq[bl]) - sigma_est[bl])
+        try:
+            self.dlr_w_max = find_w_max(G_guess, self.dlr_eps)
+        except RuntimeError:
+            # The impurity G shifted by the Hartree self energy cannot be represented by a
+            # DLR mesh whose nodes fit inside the current n_iw range. Fall back to the
+            # largest mesh-fitting cutoff (best effort) and warn that n_iw limits accuracy.
+            self.dlr_w_max = self._largest_fitting_dlr_w_max(G_guess)
+            mpi.report('HARTREE SOLVER: warning, n_iw is too small to fully represent the '
+                       'impurity Green function for the Hartree self energy shift; falling '
+                       f'back to the largest mesh-fitting DLR cutoff w_max = {self.dlr_w_max:.4f}. '
+                       'Increase n_iw for higher accuracy.')
+
+        mpi.report(f'HARTREE SOLVER: using DLR mesh with w_max = {self.dlr_w_max:.4f}, eps = {self.dlr_eps:.1e}')
+
+        # final solve on the properly sized mesh, restarting from the original guess
         # *************************************
         # this is done on every node due to very slow bcast
+        self.triqs_solver.Sigma_HF = {bl: s.copy() for bl, s in sigma_hf_init.items()}
+        self._set_dlr_G0(self.dlr_w_max)
         self.triqs_solver.solve(h_int=self.h_int, **self.triqs_solver_params)
 
         # call postprocessing
@@ -162,10 +227,12 @@ class HartreeInterface(AbstractDMFTSolver):
         Organize G_freq, G_time, Sigma_freq and G_l from hartree solver
         """
 
-        # get everything from solver
-        self.G0_freq << self.triqs_solver.G0_iw
-        self.G_freq_unsym << self.triqs_solver.G_iw
-        self.G_freq << self.triqs_solver.G_iw
+        # get everything from solver, converting the solver's DLR Matsubara Green's
+        # functions back onto the full Matsubara mesh used throughout solid_dmft
+        n_iw = self.general_params['n_iw']
+        self.G0_freq << make_gf_imfreq(self.triqs_solver.G0_iw, n_iw)
+        self.G_freq_unsym << make_gf_imfreq(self.triqs_solver.G_iw, n_iw)
+        self.G_freq << make_gf_imfreq(self.triqs_solver.G_iw, n_iw)
         self.sum_k.symm_deg_gf(self.G_freq, ish=self.icrsh)
         for bl, gf in self.Sigma_freq:
             self.Sigma_freq[bl] << self.triqs_solver.Sigma_HF[bl]

--- a/python/solid_dmft/io_tools/default.toml
+++ b/python/solid_dmft/io_tools/default.toml
@@ -181,6 +181,7 @@ method = "krylov"
 one_shot = false
 tol = 1e-5
 with_fock = false
+eps_dlr = 1e-10
 
 [dft]
 dft_code = "<none>"

--- a/python/solid_dmft/io_tools/documentation.txt
+++ b/python/solid_dmft/io_tools/documentation.txt
@@ -468,6 +468,10 @@ tol : float, default = 1e-5
         tolerance for root finder if one_shot=False.
 with_fock : bool, default = False
         include Fock exchange terms in the self-energy
+eps_dlr : float, default = 1e-10
+        DLR accuracy used to build the DLR Matsubara mesh of the Hartree solver. The DLR
+        energy cutoff w_max is determined automatically each DMFT iteration from the full
+        Matsubara Weiss field via triqs' find_w_max for this accuracy.
 
 [  dft  ]
 ---------

--- a/test/python/nio_cthyb_hartree/dmft_config.toml
+++ b/test/python/nio_cthyb_hartree/dmft_config.toml
@@ -5,7 +5,7 @@ jobname = "out"
 mu_initial_guess = 13.751
 enforce_off_diag = [false, true]
 
-n_iw = 201
+n_iw = 401
 beta = 10
 w_range = [-10, 10]
 eta = 0.05


### PR DESCRIPTION
Background

triqs_hartree_fock's ImpuritySolver now stores G0_iw/G_iw on a DLR Matsubara mesh (hartree_fock c948fe7) — the constructor takes w_max/eps instead of n_iw. solid_dmft still
uses full Matsubara meshes for the lattice Green's function, so HartreeInterface broke (unexpected keyword argument 'n_iw'). This adds a bridge using the new triqs conversion
functions make_gf_dlr_imfreq / make_gf_imfreq / find_w_max (triqs a43d8cc).

Key idea

In Hartree-Fock the self energy is a constant matrix, so the impurity G is just the Weiss field G0 shifted by Σ_HF. The DLR mesh therefore has to be sized to G, not to G0 — a
mesh sized to G0 alone under-resolves the shifted G and, crucially, its density (which is what sets Σ_HF). DLR .density() doesn't enforce the high-frequency tail moments the
way a regular MeshImFreq does, so the shift can't just be ignored.

Σ_HF is unknown before solving, and on the first iteration the seeded guess is zero (the Hartree DC is computed inside the solver), so solve() now:
1. runs a cheap estimate solve on a G0-sized DLR mesh to get the actual constant Σ_HF,
2. builds a guesstimate G = (G0⁻¹ − Σ_HF)⁻¹ and sizes the real DLR mesh from it via find_w_max,
3. redoes the final solve on that mesh, restarting from the original guess so the one_shot result is unchanged.

If the shifted G can't be represented within the current n_iw range, it falls back to the largest mesh-fitting cutoff and warns to increase n_iw, instead of crashing or
silently returning a wrong density.

Changes

- dmft_tools/solvers/hartree_interface.py — the DLR bridge (mesh sizing, fallback, conversions on solve()/postprocess()).
- io_tools/default.toml + documentation.txt — new hartree solver param eps_dlr (default 1e-10); w_max is determined automatically. dlr_w_max/dlr_eps kept on the interface for
future use once the lattice GF moves to DLR.
- test/python/nio_cthyb_hartree/dmft_config.toml — n_iw 201 → 401 (deep O-2p shell has Σ_HF ≈ −20, needing w_max ≈ 26, which doesn't fit at 201).
- test/python/nio_cthyb_hartree/ref.h5 — regenerated at n_iw=401.

Testing

- svo_hartree ✅ (w_max=2.25 auto-sized)
- nio_cthyb_hartree ✅ (w_max=25.63, no fallback)
- New nio reference verified correct: density 0.99655 vs converged truth 0.99646 — ~8× closer than the old n_iw=201 reference (0.99720). CI time +~7% (95.8s → 103s; n_iw=501
gave no accuracy gain for +13%, so 401 was chosen).

Notes for reviewers

- The nio ref.h5 was regenerated, so the test now validates against the new DLR solver output rather than the old full-mesh solver. This is justified: the new result is
measurably closer to the converged truth.
- No triqs/hartree_fock changes are required — the DLR HF case is handled entirely on the solid_dmft side. The one underlying behavior worth being aware of: DLR .density() has
no tail-moment enforcement, so for a constant Σ_HF the mesh must be sized to w_max ≳ ‖Σ_HF‖ (and n_iw large enough to represent it), which is what the bridge now does
automatically.
