### PR TITLE
[ci] Modernize OpenMPI CI images to Ubuntu 26.04 / OpenMPI 5 (fix flaky mpi_group ORTE session-dir race)

### DIFF
--- a/Docker/github_ci_dockerfile
+++ b/Docker/github_ci_dockerfile
@@ -1,5 +1,5 @@
-FROM ubuntu:24.04 AS base
-ARG LLVM=20
+FROM ubuntu:26.04 AS base
+ARG LLVM=22
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
       build-essential \
@@ -11,9 +11,9 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
       dh-python \
       clang-${LLVM} \
       clang-tools-${LLVM} \
-      gcc-14 \
-      g++-14 \
-      gfortran-14 \
+      gcc-16 \
+      g++-16 \
+      gfortran-16 \
       git \
       hdf5-tools \
       libboost-dev \
@@ -75,21 +75,24 @@ ENV OMP_NUM_THREADS=1
 ENV MKL_NUM_THREADS=1
 ENV OMPI_ALLOW_RUN_AS_ROOT=1
 ENV OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
-ENV OMPI_MCA_rmaps_base_oversubscribe="yes"
+# OpenMPI 5 moved mapping/oversubscribe from ORTE to PRRTE; the old
+# OMPI_MCA_rmaps_base_oversubscribe is ignored and np>cores would fail with
+# "not enough slots". PRRTE also fixes the concurrent-mpirun session-dir race.
+ENV PRTE_MCA_rmaps_default_mapping_policy=:oversubscribe
 ARG NCORES=8
 
 # create source dirs
 RUN cd / && mkdir -p triqs && mkdir -p source
 
-ENV PYTHON_VERSION=3.12 \
-    CC=gcc-14 CXX=g++-14 \
+ENV PYTHON_VERSION=3.14 \
+    CC=gcc-16 CXX=g++-16 \
     CLANG_CC=clang-${LLVM} CLANG_CXX=clang++-${LLVM}
 # triqs
 ENV CPATH=/triqs/include:${CPATH} \
     PATH=/triqs/bin:${PATH} \
     LIBRARY_PATH=/triqs/lib:${LIBRARY_PATH} \
     LD_LIBRARY_PATH=/triqs/lib:${LD_LIBRARY_PATH} \
-    PYTHONPATH=/triqs/lib/python3.12/site-packages:/triqs/lib/python3.12/dist-packages:${PYTHONPATH} \
+    PYTHONPATH=/triqs/lib/python${PYTHON_VERSION}/site-packages:/triqs/lib/python${PYTHON_VERSION}/dist-packages:${PYTHONPATH} \
     CMAKE_PREFIX_PATH=/triqs/share/cmake:${CMAKE_PREFIX_PATH} \
     CMAKE_BUILD_PARALLEL_LEVEL=${NCORES} \
     CTEST_OUTPUT_ON_FAILURE=1 \
@@ -158,7 +161,7 @@ RUN cd /source && git clone -b unstable --depth 1 https://github.com/TRIQS/maxen
     && make -j$NCORES && ctest -j$NCORES && make install
 
 # install sparse-ir into triqs pythonpath
-RUN pip install --no-deps --target /triqs/lib/python3.12/site-packages sparse-ir xprec
+RUN pip install --no-deps --break-system-packages --target /triqs/lib/python${PYTHON_VERSION}/site-packages sparse-ir xprec
 
 # remove source
 RUN cd / && rm -rf source

--- a/Docker/openmpi_dockerfile
+++ b/Docker/openmpi_dockerfile
@@ -1,5 +1,5 @@
-FROM --platform=linux/amd64 ubuntu:24.04 AS base
-ARG LLVM=20
+FROM --platform=linux/amd64 ubuntu:26.04 AS base
+ARG LLVM=22
 
 # This platform includes dependencies for building docs
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
@@ -16,6 +16,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
       debhelper \
       dh-python \
       g++ \
+      g++-16 \
       gfortran \
       git \
       hdf5-tools \
@@ -90,9 +91,9 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
 #     && rm -rf openmpi-4.1.5.tar.gz openmpi-4.1.5
 
 # install sparse-ir into triqs pythonpath
-RUN pip install --no-deps --target /triqs/lib/python3.12/site-packages sparse-ir xprec
+RUN pip install --no-deps --break-system-packages --target /triqs/lib/python3.14/site-packages sparse-ir xprec
 
-ENV PYTHON_VERSION=3.12 \
+ENV PYTHON_VERSION=3.14 \
     CC=clang-${LLVM} CXX=clang++-${LLVM} CXXFLAGS="-stdlib=libc++"
 RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-${LLVM} 60 --slave /usr/bin/clang++ clang++ /usr/bin/clang++-${LLVM} --slave /usr/bin/clang-cpp clang-cpp /usr/bin/clang-cpp-${LLVM}
 
@@ -102,7 +103,10 @@ ENV MKL_INTERFACE_LAYER=GNU,LP64
 ENV MKL_THREADING_LAYER=SEQUENTIAL
 ENV OMPI_ALLOW_RUN_AS_ROOT=1
 ENV OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
-ENV OMPI_MCA_rmaps_base_oversubscribe="yes"
+# OpenMPI 5 moved mapping/oversubscribe from ORTE to PRRTE; the old
+# OMPI_MCA_rmaps_base_oversubscribe is ignored and np>cores would fail with
+# "not enough slots". PRRTE also fixes the concurrent-mpirun session-dir race.
+ENV PRTE_MCA_rmaps_default_mapping_policy=:oversubscribe
 ARG NCORES=4
 
 # create source dirs
@@ -160,7 +164,7 @@ ENV CPATH=/triqs/include:/usr/include/mkl:${CPATH} \
     PATH=/triqs/bin:${PATH} \
     LIBRARY_PATH=/triqs/lib:${LIBRARY_PATH} \
     LD_LIBRARY_PATH=/triqs/lib:${LD_LIBRARY_PATH} \
-    PYTHONPATH=/triqs/lib/python3.12/site-packages:/triqs/lib/python3.12/dist-packages:${PYTHONPATH} \
+    PYTHONPATH=/triqs/lib/python${PYTHON_VERSION}/site-packages:/triqs/lib/python${PYTHON_VERSION}/dist-packages:${PYTHONPATH} \
     CMAKE_PREFIX_PATH=/triqs/share/cmake:${CMAKE_PREFIX_PATH} \
     CMAKE_BUILD_PARALLEL_LEVEL=${NCORES} \
     CTEST_OUTPUT_ON_FAILURE=1 \


### PR DESCRIPTION
## Summary

Modernize the two **OpenMPI-based GitHub Actions CI images** to `ubuntu:26.04`,
which ships **OpenMPI 5.0.10 (PRRTE/PMIx)**, clang 22, gcc 16 and Python 3.14.

This fixes intermittent MPI-test failures in the image builds, e.g.:

```
26/377 Test #27: mpi_group_np4 ...***Failed
  mkdir /tmp/ompi.buildkitsandbox.0/pid.XXXX : No such file or directory
  orte_session_dir failed  (session_dir.c:107)
```

**Root cause:** OpenMPI 4's ORTE uses one per-host session directory
(`/tmp/ompi.<host>.<uid>`) shared across concurrent `mpirun` invocations. With
`ctest -j`, two MPI tests run at once; one's cleanup removes the shared parent
while another is creating its `pid.*` subdir → a race that aborts a random MPI
test at init. It's nondeterministic (one image happened to pass, the other
failed on the identical test). OpenMPI 5 replaces ORTE with PRRTE and no longer
has this shared-session-dir race, so `ctest` can stay parallel.

## Changes (both `github_ci_dockerfile` and `openmpi_dockerfile`)

- `FROM ubuntu:24.04` → `ubuntu:26.04`
- `ARG LLVM` 20 → 22
- Python 3.12 → 3.14 (26.04 default); hardcoded `python3.12` paths parametrized
  via `${PYTHON_VERSION}` so they don't drift again
- **Oversubscribe env:** `OMPI_MCA_rmaps_base_oversubscribe=yes` was **removed in
  OpenMPI 5** (silently ignored → `np>cores` fails "not enough slots"). Replaced
  with the PRRTE equivalent `PRTE_MCA_rmaps_default_mapping_policy=:oversubscribe`.
- `pip install` gains `--break-system-packages` (PEP 668 on 26.04; harmless with `--target`)
- **github_ci** builds the stack with gcc; bumped `gcc-14` → `gcc-16` because
  clang-22 (used for clair) selects the highest gcc install dir for libstdc++
  (dir 16 on 26.04) — installing gcc-16 populates it so clair links without a pin.
- **openmpi** builds with clang + `-stdlib=libc++`, but clair is still built with
  libstdc++; added `g++-16` for the same reason.

`mpich_dockerfile` is intentionally left unchanged (MPICH/Hydra has no ORTE
session-dir race).

## Validation

Built locally on arm64 under x86 emulation:

- **github_ci** image builds through the full triqs compile; **376/377 tests pass**,
  and crucially **`mpi_group_np2` and `mpi_group_np4` both pass on OpenMPI 5** — the
  previously flaky tests. The one local failure (`nda_basic_array_and_view`, SIGTRAP
  at 0.05 s, isolated among all passing neighbours) is a suspected qemu-emulation
  artifact and should be confirmed on the native amd64 runner here.
- **openmpi** image can't be fully built under emulation (qemu `ENOSYS` in
  wannier90's `tar --xform`, unrelated to these changes), but its 26.04 package set
  resolves, `clang-22 -stdlib=libc++` compiles/links, and the PRRTE oversubscribe
  env works.

Note: the Jenkins CI continues to run against Ubuntu 24.04, so this keeps
cross-distro coverage (24.04 on Jenkins, 26.04 on the GitHub images).
